### PR TITLE
Fixed an issue with satellite output files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,17 +161,13 @@ test1_check:
 		${IMDIR}/output/test1/log.ref         \
 		>> test1.diff
 	#${SCRIPTDIR}/DiffNum.pl -b 	        \
-	#	${TESTDIR}/output_ram/sat1.nc   \
+	#	${TESTDIR}/output_ram/sat1_d20130317_t000000.nc   \
 	#	${IMDIR}/output/test1/sat1.ref  \
 	#	>> test1.diff
 	#${SCRIPTDIR}/DiffNum.pl -b 	        \
-	#	${TESTDIR}/output_ram/sat2.nc   \
+	#	${TESTDIR}/output_ram/sat2_d20130317_t000000.nc   \
 	#	${IMDIR}/output/test1/sat2.ref  \
 	#	>> test1.diff
-	#${SCRIPTDIR}/DiffNum.pl -b		  \
-	#	${TESTDIR}/output_ram/ram000_o.l  \
-	#	${IMDIR}/output/test1/ram_o.l.ref \
-	#	>> test1.diff	
 	${SCRIPTDIR}/DiffNum.pl -b		  \
 		${TESTDIR}/output_ram/ram000_o.t  \
 		${IMDIR}/output/test1/ram_o.t.ref \
@@ -197,6 +193,7 @@ test2_rundir:
 	rm -rf ${TESTDIR}
 	make rundir RUNDIR=${TESTDIR} STANDALONE="YES"
 	cp Param/${PARAMFILE}.* ${TESTDIR}/
+	cp input/sat*.dat ${TESTDIR}/
 
 test2_run:
 	cd ${TESTDIR}; \

--- a/Param/PARAM.in.test2.1st
+++ b/Param/PARAM.in.test2.1st
@@ -26,6 +26,13 @@ F			UseEfInd
 #LOGFILE
 60.0			DtWriteLogfile
 
+#SATELLITE
+60.0                    DtOutput
+2                       nSatellite
+sat1.dat                NameTrajectoryFile
+sat2.dat                NameTrajectoryFile
+F                       DoUseVAPini
+
 #STOP
 -1                      MaxIteration
 150                    	tSimulationMax

--- a/Param/PARAM.in.test2.2nd
+++ b/Param/PARAM.in.test2.2nd
@@ -19,6 +19,13 @@ F			UseEfInd
 #LOGFILE
 60.0			DtWriteLogfile
 
+#SATELLITE
+60.0                    DtOutput
+2                       nSatellite
+sat1.dat                NameTrajectoryFile
+sat2.dat                NameTrajectoryFile
+F                       DoUseVAPini
+
 #STOP
 -1                      MaxIteration
 300                    	tSimulationMax

--- a/src/ModRamIO.f90
+++ b/src/ModRamIO.f90
@@ -252,7 +252,6 @@ contains
     close(unitTMP_)
     stat = system(trim('ln -s -f '//trim(CWD)//'/'//trim(NameFile)//' '// &
                        trim(CWD)//'/'//PathRestartIn//'/restart_info.txt'))
-!    CALL SYMLINK(PathRestartIn//'/restart_info.txt',NameFile)
 
     ! Write binary portions of restart.
     do s=1, 4
@@ -267,7 +266,6 @@ contains
        close(UnitTMP_)
        stat = system(trim('ln -s -f '//trim(CWD)//'/'//trim(NameFile)//' '// &
                           trim(CWD)//'/'//PathRestartIn//'/restart_'//NameSpecies(s)//'.rst'))
-!       CALL SYMLINK(PathRestartIn//'/restart_'//NameSpecies(s)//'.rst',NameFile)
     end do
 
     NameFile=RamFileName(PathRestartOut//'/restart_ppar','rst',TimeRamNow)
@@ -281,7 +279,6 @@ contains
     close(UnitTMP_)
     stat = system(trim('ln -s -f '//trim(CWD)//'/'//trim(NameFile)//' '// &
                        trim(CWD)//'/'//PathRestartIn//'/restart_ppar.rst'))
-!    CALL SYMLINK(PathRestartIn//'/restart_ppar.rst',NameFile)
 
     NameFile=RamFileName(PathRestartOut//'/restart_pper','rst',TimeRamNow)
     if(DoTest) then
@@ -294,7 +291,6 @@ contains
     close(UnitTMP_)
     stat = system(trim('ln -s -f '//trim(CWD)//'/'//trim(NameFile)//' '// &
                        trim(CWD)//'/'//PathRestartIn//'/restart_pper.rst'))
-!    CALL SYMLINK(PathRestartIn//'/restart_pper.rst',NameFile)
 
   end subroutine write_restart
 

--- a/src/ModRamSats.f90
+++ b/src/ModRamSats.f90
@@ -21,6 +21,7 @@ module ModRamSats
   integer            :: nSatPoints_I(MaxRamSat)
   integer            :: iSatTime_I(MaxRamSat) = 1
   character(len=200) :: SatFileName_I(MaxRamSat), SatName_I(MaxRamSat)
+  character(len=200) :: SatFileName_O(MaxRamSat)
   character(len=3)   :: TypeSatCoord_I(MaxRamSat)
 
   ! Info about the sat output netcdf files.
@@ -292,8 +293,8 @@ contains
          SatFileName = RamFileName(SatName_I(i),'nc',TimeRamStart)
       end if
       ! Replace now-useless input file name with output file name.
-      SatFileName_I(i) = trim(PathRamOut)//'/'//trim(SatFileName)
-      call create_sat_file(SatFileName_I(i))
+      SatFileName_O(i) = trim(PathRamOut)//trim(SatFileName)
+      call create_sat_file(SatFileName_O(i))
     end do
 
   end subroutine init_sats
@@ -327,7 +328,7 @@ contains
          ' Creating NetCDF File ', trim(FileNameIn)
 
     ! Open file; check for success.
-    iStatus = nf90_create(FileNameIn, nf90_clobber, iFileID)
+    iStatus = nf90_create(trim(FileNameIn), nf90_clobber, iFileID)
     call ncdf_check(iStatus, NameSub)
 
 
@@ -606,15 +607,14 @@ contains
         SatB = BadDataFlag; SatEc = BadDataFlag
         SatFlux = BadDataFlag; OmnFlux = BadDataFlag
         xyzNear = BadDataFlag; BtNear = BadDataFlag
-        if(IsRestart) then
-           TimeRamRestart%Time = TimeRamStart%Time + TimeRestart
-           call time_real_to_int(TimeRamRestart)
-           SatFileName = RamFileName(SatName_I(iSat),'nc',TimeRamRestart)
-        else
-           SatFileName = RamFileName(SatName_I(iSat),'nc',TimeRamStart)
-        end if
-        FileName = trim(PathRamOut)//'/'//trim(SatFileName)
-        call append_sat_record(FileName, iSatRecord(iSat), TimeRamElapsed, &
+!        if(IsRestart) then
+!           TimeRamRestart%Time = TimeRamStart%Time + TimeRestart
+!           call time_real_to_int(TimeRamRestart)
+!           SatFileName = RamFileName(SatName_I(iSat),'nc',TimeRamRestart)
+!        else
+!           SatFileName = RamFileName(SatName_I(iSat),'nc',TimeRamStart)
+!        end if
+        call append_sat_record(SatFileName_O(iSat), iSatRecord(iSat), TimeRamElapsed, &
              xSat, SatB, SatEc, SatFlux, OmnFlux, xyzNear, BtNear) !, SatEi
         iSatRecord(iSat) = iSatRecord(iSat) + 1
         cycle SATLOOP                 ! don't trace this time.
@@ -769,8 +769,7 @@ contains
       end if
  
        ! Write information to output file.
-       FileName = trim(PathRamOut)//'/'//trim(SatName_I(iSat))//'.nc'
-       call append_sat_record(FileName, iSatRecord(iSat), TimeRamElapsed, &
+       call append_sat_record(trim(SatFileName_O(iSat)), iSatRecord(iSat), TimeRamElapsed, &
             xSat, SatB, SatEc, SatFlux, OmnFlux, xyzNear, BtNear) !, SatEi
 
        ! Increment record location in NCDF file.


### PR DESCRIPTION
Satellite output files should now be working correctly. Also added satellites to test2 in order to test the restart capability of the satellite files.

Fixes an issue introduced recently where satellite output files were not being populated, so all satellite output files were empty "templates".