### PR TITLE
Re-enable RAM species OpenMP

### DIFF
--- a/src/ModRamDrift.f90
+++ b/src/ModRamDrift.f90
@@ -13,10 +13,11 @@ MODULE ModRamDrift
 
   implicit none
 
-  integer :: QS
-  real(kind=Real8_), ALLOCATABLE :: VR(:), P1(:), P2(:,:), MUDOT(:,:), EDOT(:,:), &
-                                    CDriftR(:,:,:,:), CDriftP(:,:,:,:), &
-                                    CDriftE(:,:,:,:), CDriftMu(:,:,:,:)
+  integer, save :: QS
+  real(kind=Real8_), save, ALLOCATABLE :: VR(:), P1(:), P2(:,:), MUDOT(:,:), EDOT(:,:), &
+                                          CDriftR(:,:,:,:), CDriftP(:,:,:,:), &
+                                          CDriftE(:,:,:,:), CDriftMu(:,:,:,:)
+  !$OMP THREADPRIVATE(QS,VR,P1,P2,MUDOT,EDOT,CDriftR,CDriftP,CDriftE,CDriftMu)
 
   contains
 !==============================================================================

--- a/src/ModRamRun.f90
+++ b/src/ModRamRun.f90
@@ -63,7 +63,7 @@ MODULE ModRamRun
        CALL PLANE(TimeRamNow%iYear,DAY,T,KP,IAPO(2),RZ(3),F107,2.*DTs,NECR,VT/1e3)
     END IF
 
-  !OMP PARALLEL DO
+  !$OMP PARALLEL DO
     do iS=1,4
        !   calls for given species S:
        CALL CEPARA(iS)
@@ -131,7 +131,7 @@ MODULE ModRamRun
        ! Routines needed to clear allocated variables for use with OpenMP
        CALL DRIFTEND
     end do
-  !OMP END PARALLEL DO
+  !$OMP END PARALLEL DO
 
     DtsNext = min(minval(DtDriftR), minval(DtDriftP), minval(DtDriftE), minval(DtDriftMu))
     DtsNext = max(DtsNext, DtsMin)


### PR DESCRIPTION
Disabled RAM species OpenMP for testing and forgot to re-enable it. This just makes RAM work on up to 4 cores now.