### PR TITLE
Converted 2DFlux write from ASCII to netcdf-4

### DIFF
--- a/src/IM_set_parameters.f90
+++ b/src/IM_set_parameters.f90
@@ -11,7 +11,7 @@ subroutine IM_set_parameters
                            TimeRamNow, DtLogFile, DtRestart, DtsMax, TimeMax, &
                            TimeRestart, MaxIter, Dt_hI, Dt_bc, DtEfi, DtW_hI, &
                            DtW_Pressure, DtW_EField, DtsMin, TOld, TimeRamFinish, &
-                           DtW_MAGxyz
+                           DtW_MAGxyz, DtW_2DFlux
   use ModScbGrids, ONLY: nthe, npsi, nzeta
   use ModRamParams
   use ModScbParams
@@ -288,7 +288,8 @@ subroutine IM_set_parameters
         call read_var('UseNewFormat', UseNewFmt)
 
      case('#SAVEFLUX')
-        call read_var('DoSaveFlux',DoWriteFlux)
+        call read_var('DoSaveFlux',DtW_2DFlux)
+        if (DtW_2DFlux.lt.1.0) DtW_2DFlux = 99999999999.9
 
      case('#DUMP3DFLUX')
         call read_var('DoDump3dFlux', TempLogical)

--- a/src/ModRamGrids.f90
+++ b/src/ModRamGrids.f90
@@ -8,12 +8,15 @@ Module ModRamGrids
   use nrtype, ONLY: DP
 
   implicit none
-  
+ 
+  integer, parameter :: nS = 4 ! number of species
+  character(len=2), dimension(nS) :: s_name = (/'_e',     '_H', 'He', '_O'/)
+  real(DP), dimension(nS)         :: M1     = (/5.4462E-4, 1.,   4.,   16./) !Mass number
+ 
   !!! RAM Grids
   integer :: NR       = 20,  &  ! grid points in radial direction 
              NT       = 25,  &  ! grid points in local time direction
              NE       = 35,  &  ! number of energy bins
-             NS       = 4,   &  ! number of species
              NPA      = 72,  &  ! grid points in pitch angle dimension
              NEL      = 36,  &  ! Energy bins in boundary file (for SWMF or LANL)
              NEL_prot = 36,  &  ! Energy bins in bound file for protons (SWMF or LANL)

--- a/src/ModRamTiming.f90
+++ b/src/ModRamTiming.f90
@@ -38,7 +38,8 @@ module ModRamTiming
               DtW_Pressure = 300.0,  &
               DtW_hI       = 300.0,  &
               DtW_EField   = 3600.0, &
-              DtW_MAGxyz   = 300.0
+              DtW_MAGxyz   = 300.0,  &
+              DtW_2DFlux   = 3600.0
   real(DP) :: T, UTs
   real(DP) :: Efficiency = 0.0, SysTimeStart, SysTimeNow
   real(DP) :: dtPrintTiming = 300.0
@@ -198,7 +199,8 @@ module ModRamTiming
          DtW_Pressure-mod(TimeIn, DtW_Pressure), &
          DtW_EField  -mod(TimeIn, DtW_EField  ), &
          DtW_hI      -mod(TimeIn, DtW_hI      ), &
-         DtW_MAGxyz  -mod(TimeIn, DtW_MAGxyz  )) / 2.0
+         DtW_MAGxyz  -mod(TimeIn, DtW_MAGxyz  ), &
+         DtW_2DFlux  -mod(TimeIn, DtW_2DFlux  )) / 2.0
 
     if(DoTestMe)then
        write(*,'(2a,f11.2,a)')NameSub,' using these values at t=',TimeIn,':'


### PR DESCRIPTION
Changed the 2DFlux output from a ascii file to a netcdf-4 (HDF5) file.
This cuts the size by ~75% and makes it easier for other programs to
read it in. Also added a PARAM time option instead of outputing the 
flux every hour hardcoded. 

Other file outputs from RAM and SCB should be converted to netcdf-4 
as well