### PR TITLE
Change 2D flux write from ASCII dump to netcdf-4 + gcc fix

### DIFF
--- a/src/IM_set_parameters.f90
+++ b/src/IM_set_parameters.f90
@@ -11,7 +11,7 @@ subroutine IM_set_parameters
                            TimeRamNow, DtLogFile, DtRestart, DtsMax, TimeMax, &
                            TimeRestart, MaxIter, Dt_hI, Dt_bc, DtEfi, DtW_hI, &
                            DtW_Pressure, DtW_EField, DtsMin, TOld, TimeRamFinish, &
-                           DtW_MAGxyz
+                           DtW_MAGxyz, DtW_2DFlux
   use ModScbGrids, ONLY: nthe, npsi, nzeta
   use ModRamParams
   use ModScbParams
@@ -288,7 +288,8 @@ subroutine IM_set_parameters
         call read_var('UseNewFormat', UseNewFmt)
 
      case('#SAVEFLUX')
-        call read_var('DoSaveFlux',DoWriteFlux)
+        call read_var('DoSaveFlux',DtW_2DFlux)
+        if (DtW_2DFlux.lt.1.0) DtW_2DFlux = 99999999999.9
 
      case('#DUMP3DFLUX')
         call read_var('DoDump3dFlux', TempLogical)

--- a/src/Makefile
+++ b/src/Makefile
@@ -54,11 +54,9 @@ PLE_OBJECTS=                  \
         fct-source.o          \
         irisub_2012.o         \
         iritec.o              \
-        iri87.o               \
         iriflip.o             \
         iridreg.o             \
         irifun_2012.o         \
-        msis86.o              \
         nrlmsise00_sub.o      \
         igrf.o
 

--- a/src/ModRamGrids.f90
+++ b/src/ModRamGrids.f90
@@ -8,12 +8,15 @@ Module ModRamGrids
   use nrtype, ONLY: DP
 
   implicit none
-  
+ 
+  integer, parameter :: nS = 4 ! number of species
+  character(len=2), dimension(nS) :: s_name = (/'_e',     '_H', 'He', '_O'/)
+  real(DP), dimension(nS)         :: M1     = (/5.4462E-4, 1.,   4.,   16./) !Mass number
+ 
   !!! RAM Grids
   integer :: NR       = 20,  &  ! grid points in radial direction 
              NT       = 25,  &  ! grid points in local time direction
              NE       = 35,  &  ! number of energy bins
-             NS       = 4,   &  ! number of species
              NPA      = 72,  &  ! grid points in pitch angle dimension
              NEL      = 36,  &  ! Energy bins in boundary file (for SWMF or LANL)
              NEL_prot = 36,  &  ! Energy bins in bound file for protons (SWMF or LANL)

--- a/src/ModRamTiming.f90
+++ b/src/ModRamTiming.f90
@@ -38,7 +38,8 @@ module ModRamTiming
               DtW_Pressure = 300.0,  &
               DtW_hI       = 300.0,  &
               DtW_EField   = 3600.0, &
-              DtW_MAGxyz   = 300.0
+              DtW_MAGxyz   = 300.0,  &
+              DtW_2DFlux   = 3600.0
   real(DP) :: T, UTs
   real(DP) :: Efficiency = 0.0, SysTimeStart, SysTimeNow
   real(DP) :: dtPrintTiming = 300.0
@@ -198,7 +199,8 @@ module ModRamTiming
          DtW_Pressure-mod(TimeIn, DtW_Pressure), &
          DtW_EField  -mod(TimeIn, DtW_EField  ), &
          DtW_hI      -mod(TimeIn, DtW_hI      ), &
-         DtW_MAGxyz  -mod(TimeIn, DtW_MAGxyz  )) / 2.0
+         DtW_MAGxyz  -mod(TimeIn, DtW_MAGxyz  ), &
+         DtW_2DFlux  -mod(TimeIn, DtW_2DFlux  )) / 2.0
 
     if(DoTestMe)then
        write(*,'(2a,f11.2,a)')NameSub,' using these values at t=',TimeIn,':'

--- a/src/plane_scb.f90
+++ b/src/plane_scb.f90
@@ -390,24 +390,29 @@
 !      Rs = Rsun(f10p7)
       
       iMass = 0
-      if(UseNRL_MSISE) then
+
+      !if(UseNRL_MSISE) then
          call gts7(iyd, sec, altr, glt, glng, sLT, &
               f10p7, f10p7, ap, iMass, d, exoT)      
-      else
-         call gts5(iyd, sec, altr, glt, glng, sLT, &
-              f10p7, f10p7, ap, iMass, d, exoT)
-      endif
+      !else
+      !   call gts5(iyd, sec, altr, glt, glng, sLT, &
+      !        f10p7, f10p7, ap, iMass, d, exoT)
+      !endif
+
       Tn = exoT(2)
       iMass = 16
-      if(UseNRL_MSISE) then
+
+      !if(UseNRL_MSISE) then
          call gts7(iyd, sec, altr, glt, glng, sLT, &
               f10p7, f10p7, ap, iMass, d, exoT)
-      else
-         call gts5(iyd, sec, altr, glt, glng, sLT, &
-              f10p7, f10p7, ap, iMass, d, exoT)
-      endif
+      !else
+      !   call gts5(iyd, sec, altr, glt, glng, sLT, &
+      !        f10p7, f10p7, ap, iMass, d, exoT)
+      !endif
+
       nO = d(2)                                                     ! O
-      if(UseIRI_2012) then
+
+      !if(UseIRI_2012) then
 ! Since day is day-of-year, I store this as a negative number in mmdd
          mmdd = -day
          hours = sec/3600.
@@ -421,10 +426,11 @@
          Ti = OUTF(3,1)
          Te = OUTF(4,1)
 
-      else
-         call iri(altr, jMag, mLat, mLong, Rs, month, sLT, &
-              nOp, Ti, Te, magbr)                                  ! Ti, Te
-      endif      
+      !else
+      !   call iri(altr, jMag, mLat, mLong, Rs, month, sLT, &
+      !        nOp, Ti, Te, magbr)                                  ! Ti, Te
+      !endif      
+
       rf = RE_cm + altr*1.e5
       g = 980.*(RE_cm/rf)**2
       HOp = KB*(Ti + Te)/(MOP*g)
@@ -434,24 +440,27 @@
 
       alt0 = altr - Hp*log( (2.e19/(nOp*nO)) * (Ti/Hc)**2 )
       iMass = 0
-      if(UseNRL_MSISE) then
+      !if(UseNRL_MSISE) then
          call gts7(iyd, sec, alt0, glt, glng, sLT, &
               f10p7, f10p7, ap, iMass, d, exoT)
-      else
-         call gts5(iyd, sec, alt0, glt, glng, sLT, &
-              f10p7, f10p7, ap, iMass, d, exoT)
-      endif
+      !else
+      !   call gts5(iyd, sec, alt0, glt, glng, sLT, &
+      !        f10p7, f10p7, ap, iMass, d, exoT)
+      !endif
       Tn = exoT(2)
       iMass = 1
-      if(UseNRL_MSISE) then
+
+      !if(UseNRL_MSISE) then
          call gts7(iyd, sec, alt0, glt, glng, sLT, &
               f10p7, f10p7, ap, iMass, d, exoT)
-      else
-         call gts5(iyd, sec, alt0, glt, glng, sLT, &
-              f10p7, f10p7, ap, iMass, d, exoT)
-      endif
+      !else
+      !   call gts5(iyd, sec, alt0, glt, glng, sLT, &
+      !        f10p7, f10p7, ap, iMass, d, exoT)
+      !endif
+
       nH = d(7)                                                    ! H
-      if(UseIRI_2012) then
+
+      !if(UseIRI_2012) then
          heibeg = alt0
          heiend = alt0
          heistp = 1
@@ -462,10 +471,11 @@
          Ti = OUTF(3,1)
          Te = OUTF(4,1)
 
-      else
-         call iri(alt0, jMag, mLat, mLong, Rs, month, sLT, &
-              nOp, Ti, Te, magbr)                                 ! O^+
-      endif
+      !else
+      !   call iri(alt0, jMag, mLat, mLong, Rs, month, sLT, &
+      !        nOp, Ti, Te, magbr)                                 ! O^+
+      !endif
+
       r0 = RE_cm + alt0*1.e5
       g = 980.*(RE_cm/r0)**2
       HOp = KB*(Ti+Te)/(MOP*g)


### PR DESCRIPTION
RAM 2D Flux was written every hour as an ascii dump if requested. Turned it into a configurable time based write with a compressed netcdf-4 output to conserve space.

New versions of GCC would not compile the iri87 and msis86 code. Removed their calls and stopped the compiler from linking against them as they were not needed