### PR TITLE
Updated restart saving when coupled with SWMF

### DIFF
--- a/src/ModRamMain.f90
+++ b/src/ModRamMain.f90
@@ -21,7 +21,7 @@ module ModRamMain
 !!!!! PATHS
   ! File paths for restarts
   character(len=*), parameter :: PathRestartIn = 'IM/restartIN'
-  character(len=*), parameter :: PathRestartOut= 'IM/restartOUT'
+  character(len=999) :: PathRestartOut= 'IM/restartOUT'
 
   ! File paths to fix hardcoding of path issues.
   character(len=*), parameter :: PathRAMOut  = 'IM/output/ram/'

--- a/src/ModRamRestart.f90
+++ b/src/ModRamRestart.f90
@@ -47,7 +47,7 @@ module ModRamRestart
                nZetaDim
     integer, parameter :: iDeflate = 2, yDeflate = 1
 
-    character(len=200) :: NameFile
+    character(len=999) :: NameFile
 
     character(len=*), parameter :: NameSub='write_restart'
     logical :: DoTest, DoTestMe
@@ -59,9 +59,9 @@ module ModRamRestart
 
     ! Write ascii portion of restart.
     if (TimedRestarts) then
-       NameFile=RamFileName(PathRestartOut//'/restart_info','txt',TimeRamNow)
+       NameFile=RamFileName(trim(PathRestartOut)//'/restart_info','txt',TimeRamNow)
     else
-       NameFile=PathRestartOut//'/restart_info.txt'
+       NameFile=trim(PathRestartOut)//'/restart_info.txt'
     endif
     open(unit=UnitTMP_, file=trim(NameFile), status='replace')
     write(UnitTMP_, *) 'TIMING:'
@@ -76,9 +76,9 @@ module ModRamRestart
 
     ! OPEN FILE
     if (TimedRestarts) then
-       NameFile = RamFileName(PathRestartOut//'/restart','nc',TimeRamNow)
+       NameFile = RamFileName(trim(PathRestartOut)//'/restart','nc',TimeRamNow)
     else
-       NameFile = PathRestartOut//'/restart.nc'
+       NameFile = trim(PathRestartOut)//'/restart.nc'
     endif
     iStatus = nf90_create(trim(NameFile), nf90_HDF5, iFileID)
     call ncdf_check(iStatus, NameSub)

--- a/srcInterface/IM_wrapper.f90
+++ b/srcInterface/IM_wrapper.f90
@@ -742,7 +742,10 @@ module IM_wrapper
   !=============================================================================
   
   subroutine IM_save_restart(TimeSimulation)
-    
+
+    use CON_coupler,   ONLY: NameRestartOutDirComp
+    use ModRamParams,  ONLY: TimedRestarts
+    use ModRamMain,    ONLY: PathRestartOut
     use ModRamRestart, ONLY: write_restart
     
     implicit none
@@ -751,7 +754,11 @@ module IM_wrapper
     real,     intent(in) :: TimeSimulation   ! seconds from start time
     character(len=*), parameter :: NameSub='IM_save_restart'
     !---------------------------------------------------------------------------
-    
+  
+    if (NameRestartOutDirComp /= '') then
+       PathRestartOut = NameRestartOutDirComp
+       TimedRestarts = .false.
+    endif  
     call write_restart
     
   end subroutine IM_save_restart


### PR DESCRIPTION
Replaced the PathRestartOut parameter with a variable that changes when
coupled with the framework so that restart files are saved in the
same place as they are for RCM.

This change allows the Restart.pl perl script from the SWMF to handle
RAM correctly, so there is no more need to copy files from restartOUT to
restartIN.