### PR TITLE
Updates to helper scripts

### DIFF
--- a/Scripts/CatLog.py
+++ b/Scripts/CatLog.py
@@ -39,84 +39,89 @@ debug=False
 remove=False
 files=[]
 
+#TODO: replace with argparse option parser
 for option in sys.argv[1:]:
     # Handle options.
     if option[0]=='-':
         if option == '-nocheck':
-            check=False
+            check = False
         elif option == '-rm':
-            remove='True'
+            remove = 'True'
         elif option == '-debug':
-            debug=True
+            debug = True
         elif option == '-h' or option == '-help':
-            print __doc__
+            print(__doc__)
             exit()
         else:
-            print 'Unrecognized option: ', option
-            print __doc__
+            print('Unrecognized option: ', option)
+            print(__doc__)
             exit()
     else:
-        files=files+glob(option)
+        files = files + glob(option)
 
 # Open output file in append mode:
-out=open(files.pop(0), 'a+')
+out = open(files.pop(0), 'a+')
 
 # Some machines don't do 'a+' correctly.  Rewind file as necessary.
 if out.tell()>0: out.seek(0,0)
 
 # Load and store header:
 out.readline() #garbage
-head=out.readline() # Header.
-nbytes=len(out.readline())
+head = out.readline() # Header.
+nbytes = len(out.readline())
 if debug:
-    print "DEBUG:\tOpened file %s" % (out.name)
-    print "\tEach line is %i characters long." % nbytes
-    print "\tHeader has %i entries." % (len(head.split()))
+    print("DEBUG:\tOpened file %s" % (out.name))
+    print("\tEach line is %i characters long." % nbytes)
+    print("\tHeader has %i entries." % (len(head.split())) )
 
 # Load last line of file.
 out.seek(-1*nbytes, 2) #seek last line.
-lasttime = float( (out.readline().split())[0])
+lasttime = float((out.readline().split())[0])
 
 if debug:
-    print "\tLast time = %f." % lasttime
+    print("\tLast time = %f." % lasttime)
 
 # Open rest of files, append.
 for f in files:
     # No files that end with special characters.
     if f[-1]=='~': continue
     # Open file, slurp lines.
-    if debug: print "Processing %s:" % f
-    nextfile=open(f, 'r')
-    lines=nextfile.readlines()
+    if debug: print("Processing %s:" % f)
+    nextfile = open(f, 'r')
+    lines = nextfile.readlines()
     nextfile.close()
     # Read header; skip this file if header is different.
     lines.pop(0)
-    nowhead=lines.pop(0)
-    if nowhead!=head: 
+    nowhead = lines.pop(0)
+    if nowhead != head: 
         if debug: 
-            print head
-            print nowhead
-            print "\tHeader does not match, discarding."
+            print(head)
+            print(nowhead)
+            print("\tHeader does not match, discarding.")
         continue
     # Jump over overlapping lines:
     if check:
-        nSkip=0; nLines=len(lines)
+        nSkip=0
+        nLines=len(lines)
         while nSkip<nLines:
             if float( (lines[0].split())[0] ) > lasttime:
                 break
             else:
                 lines.pop(0)
-                nSkip+=1
-        if debug: print "\tFound %i overlapping lines." % nSkip
+                nSkip += 1
+        if debug:
+            print("\tFound %i overlapping lines." % nSkip)
     # Append data to first log.
-    if len(lines)<1: continue
+    if len(lines)<1:
+        continue
     for l in lines:
         out.write(l)
     # Save "last time".
     lasttime=float( (lines[-1].split())[0] )
     # Delete file when done.
     if remove: 
-        if debug: print "\tRemoving file."
+        if debug:
+            print("\tRemoving file.")
         unlink(f)
 
 # Finalize:

--- a/Scripts/provisionalIndices.py
+++ b/Scripts/provisionalIndices.py
@@ -137,9 +137,9 @@ if __name__=='__main__':
     #download updated F10.7 from ftp://ftp.geolab.nrcan.gc.ca/data/solar_flux/daily_flux_values/fluxtable.txt
     #only has data from 2004-10-28 (prior data are in different files)
     io_store = io.StringIO()
-    ftp = ftplib.FTP('ftp.geolab.nrcan.gc.ca')
+    ftp = ftplib.FTP('ftp.seismo.nrcan.gc.ca')
     ftp.login()
-    ftp.cwd('data/solar_flux/daily_flux_values')
+    ftp.cwd('spaceweather/solar_flux/daily_flux_values')
     ftp.retrlines('RETR {0}'.format('fluxtable.txt'), io_store.write)
     io_store.seek(0)
     conts = io_store.read()

--- a/ccmcSetup.sh
+++ b/ccmcSetup.sh
@@ -7,7 +7,7 @@
 module purge
 LD_LIBRARY_PATH=
 module load gcc-9.2.0
-#TODO: add module load for netcdf here
+module load netcdf-c-4.7.2/gcc-9.2.0
 module load netcdf-fortran-4.5.2/gcc-9.2.0
 module load openmpi-3.1.4/gcc-9.2.0
 conda activate python37
@@ -15,10 +15,12 @@ conda activate python37
 PKG_CONFIG_PATH=/opt/gnu/gsl-2.5/lib/pkgconfig/
 LD_LIBRARY_PATH=/opt/gnu/gsl-2.5/lib:$LD_LIBRARY_PATH
 NCDF=/act/netcdf-fortran-4.5.2/gcc-9.2.0
+GSL=/opt/gnu/gsl-2.5
 
-./Config.pl -install -compiler=gfortran -mpi=openmpi -ncdf=${NCDF} -gsl=/opt/gnu/gsl-2.5 -openmp
+./Config.pl -install -compiler=gfortran -mpi=openmpi -ncdf=${NCDF} -gsl=${GSL} -openmp
 #now fix the GSL include and link stuff in the make system
-sed -i 's/^\(FLAGC.*\)/SEARCH_C = `pkg-config --cflags --libs gsl`\n\1/' Makefile.conf
+GSL_FLAGS=`pkg-config --cflags --libs gsl`
+sed "s|^\(FLAGC.*\)|SEARCH_C = -I$GSL/include\\nFLAGC_EXTRA = $GSL_FLAGS\\n\\1|" Makefile.conf
 
 #Then compile
-Make
+make

--- a/ccmcSetup.sh
+++ b/ccmcSetup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+###
+#  INSTALL SCRIPT FOR LAHAINA01
+###
+
+module purge
+LD_LIBRARY_PATH=
+module load gcc-9.2.0
+#TODO: add module load for netcdf here
+module load netcdf-fortran-4.5.2/gcc-9.2.0
+module load openmpi-3.1.4/gcc-9.2.0
+conda activate python37
+
+PKG_CONFIG_PATH=/opt/gnu/gsl-2.5/lib/pkgconfig/
+LD_LIBRARY_PATH=/opt/gnu/gsl-2.5/lib:$LD_LIBRARY_PATH
+NCDF=/act/netcdf-fortran-4.5.2/gcc-9.2.0
+
+./Config.pl -install -compiler=gfortran -mpi=openmpi -ncdf=${NCDF} -gsl=/opt/gnu/gsl-2.5 -openmp
+#now fix the GSL include and link stuff in the make system
+sed -i 's/^\(FLAGC.*\)/SEARCH_C = `pkg-config --cflags --libs gsl`\n\1/' Makefile.conf
+
+#Then compile
+Make


### PR DESCRIPTION
This PR provides further updates to the Python helper scripts:
- CatLog.py: for concatenating/merging log files. Finalizing Python 3 compatibility and some formatting for readability.
- provisionalIndices.py: for fetching provisional/realtime indices. Update URL for fetching F10.7 from NRCan.

It also provides a helper script for installing RAM-SCB in standalone mode for CCMC.
This script cleans the environment, loads required modules, sets variables and calls `Config.pl` to generate the Makefile includes. Then `Makefile.def` is edited to fix the C compiler flags for gcc, and finally `make` is run.