### PR TITLE
Added a new plasmasphere model

### DIFF
--- a/Param/PARAM.in.default
+++ b/Param/PARAM.in.default
@@ -66,12 +66,22 @@ F			UseEfInd		! Whether or not to use an inductive electric field
 F			DoUseWPI		! Whether to use wave particle interactions or not (Note, wave particle interactions are not currently working)
 F			DoUseBASDiff		! Whether to use BAS diffusion coefficients for wave particle interactions
 F			doUseKpDiff		! Whether to use KP based diffusion coefficients for wave particle interactions
+
+#PLASMASPHERE
+F			DoUsePlasmasphere       ! Whether or not to use a plasmasphere model
+Carpenter               PlasmasphereModel       ! If DoUsePlasmasphere then which plasmasphere model to use (Carpenter,Transport)
+Analytic                TauCalculation          ! How to calculate plasmasphere refilling time (Fixed, Analytic, Rasmussen)
+
+#COULOMB
+F			DoUseCoulomb            ! Whether or not to use coulomb collisions
+
 ***********************************************
 
 ***************** RAM BLOCK *******************
-#MULTISPECIESBCS
-F                       DoMultiSpeciesBcs       ! Whether to use boundary flux files that are split into multiple species (H+, He, O)
-T                       DoElectrons             ! Whether to run electrons
+#SPECIES
+4			nS			! Number of species to run
+_H _O He _e		SpeciesCodes		! Set of two letter codes for each species
+F			FixedComposition	! Use a fixed composition ratio for ions or Young et al.
 
 #RAMLIMITER
 1.5                     LimiterBeta             ! When running, RAM will limit beta to this value
@@ -82,8 +92,9 @@ T                       DoElectrons             ! Whether to run electrons
 35                      nE                      ! Number of energy bins used in RAM
 72                      nPa                     ! Number of pitch angle bins used in RAM
 
-#USEPLANE
-F			DoUsePlane_SCB		! Whether to include the plasmasphere
+#FLUX_CAP
+1e10			ElectronFluxCap		! Boundary flux cap for electrons
+1e8			ProtonFluxCap		! Boundary flux cap for ions
 
 ***********************************************
 
@@ -106,6 +117,10 @@ F			DoUsePlane_SCB		! Whether to include the plasmasphere
 71                      nTheta                  ! Number of theta (polar) grid points used in SCB
 45                      nPsi                    ! Number of psi (radial) surfaces used in SCB
 73                      nZeta                   ! Number of zeta (azimuthal) surfaces used in SCB 
+
+#SCB_GHOSTCELLS
+0			RadialGhostCells	! Number of radial ghost cells
+4			ToroidalGhostCells	! Number of field line ghost cells
 
 #SCBFLAGS
 F			Isotropic		! Whether to use isotropic pressure mappings in SCB (does not effect RAM)

--- a/src/IM_set_parameters.f90
+++ b/src/IM_set_parameters.f90
@@ -82,6 +82,16 @@ subroutine IM_set_parameters
      case('#USERAM')
         call read_var('DoUseRAM', DoUseRAM)
 
+     case('#PLASMASPHERE')
+        call read_var('UsePlasmasphere', DoUsePlasmasphere)
+        if (DoUsePlasmasphere) then
+           call read_var('PlasmasphereModel', PlasmasphereModel)
+           call read_var('TauCalculation', TauCalculation)
+        endif
+
+     case('#COULOMB')
+        call read_var('UseCoulomb', DoUseCoulomb)
+
      case('#SPECIES')
         call read_var('nS', nS)
         call read_var('NameVar', NameVar)
@@ -98,10 +108,6 @@ subroutine IM_set_parameters
 
      case('#CHECK_MAGNETOPAUSE')
         checkMGNP = .true.
-
-     case('#USEPLANE')
-        DoUsePlane_SCB = .true.
-        call read_var('DoUsePlane_SCB', DoUsePlane_SCB)
 
      case('#USEWPI')
         call read_var('DoUseWPI',     TempLogical)

--- a/src/ModRamIO.f90
+++ b/src/ModRamIO.f90
@@ -672,7 +672,7 @@ end subroutine read_geomlt_file
     use ModRamMain,  ONLY: DP, PathRamOut
     use ModRamTiming, ONLY: TimeRamNow
     use ModRamGrids, ONLY: nS, nR, nT, nE, nPa
-    use ModRamVariables, ONLY: F2, FFactor, FNHS, EkeV, Lz, Pa, MLT, species
+    use ModRamVariables, ONLY: F2, FFactor, FNHS, EkeV, Lz, Pa, MLT, species, nECR
 
     use ModRamNCDF
     use netcdf
@@ -684,7 +684,7 @@ end subroutine read_geomlt_file
 
     character(len=200) :: NameFile
     integer :: i, j, k, l, S
-    integer :: nRDim, nTDim, nEDim, nPaDim, iGridVar, iFluxVar, iFileID, iStatus
+    integer :: nRDim, nTDim, nEDim, nPaDim, iGridVar, iFluxVar, iFileID, iStatus, iNECRVar
     real(DP), allocatable :: F(:,:,:,:)
 
     ! OPEN FILE
@@ -733,6 +733,10 @@ end subroutine read_geomlt_file
        iStatus = nf90_put_var(iFileID, iFluxVar,  F(:,:,:,:))
     enddo
     deallocate(F)
+
+    !! Plasmaspheric Densities
+    iStatus = nf90_def_var(iFileID, 'NECR', nf90_double, (/nRDim,nTDim/), iNECRVar)
+    iStatus = nf90_put_var(iFileID, iNECRVar, NECR(1:nR,1:nT))
 
     iStatus = nf90_close(iFileID)
     call ncdf_check(iStatus, NameSub)
@@ -791,7 +795,7 @@ end subroutine read_geomlt_file
                                LECD, LECN, outsideMGNP, NECR, IAPO, RZ, &
                                IR1, IP1, PHI, MU, RFACTOR, ESUM, NSUM
     use ModRamTiming,    ONLY: TimeRamNow,TimeRamElapsed
-    use ModRamParams,    ONLY: DoUseWPI, DoUsePlane_SCB
+    use ModRamParams,    ONLY: DoUseWPI, DoUsePlasmasphere
     use ModRamFunctions
     use ModRamConst
     use ModIOUnit, ONLY: UNITTMP_, io_unit_new
@@ -901,7 +905,7 @@ end subroutine read_geomlt_file
 32  FORMAT(' EKEV/PA, Date=',a,' L=',F6.2,' Kp=',F6.2,' MLT=',F4.1)
 
 !.......Write the plasmaspheric electron density [cm-3] (.in)
-	  if(DoUsePlane_SCB)then
+	  if(DoUsePlasmasphere)then
 	   NameFileOut=trim(PathRamOut)//RamFileName('plasmne','in',TimeRamNow)
 	   OPEN(UNIT=UNITTMP_,FILE=NameFileOut,STATUS='UNKNOWN')
            WRITE(UNITTMP_,96) T/3600,KP,IAPO(2),RZ(3),StringDate

--- a/src/ModRamParams.f90
+++ b/src/ModRamParams.f90
@@ -38,10 +38,6 @@ module ModRamParams
   logical :: IsRestart = .false., DoSaveFinalRestart=.true.
   logical :: HardRestart = .false. ! Whether to recompute SCB outer boundary
  
-  ! Use plasmasphere density from Rasmussen model, coupled to MSIS and IRI
-  ! For plane_scb options, see ModRamPl_Ne.f90
-  logical :: DoUsePlane_SCB = .false.
- 
   ! Include SCB?  Default is yes!
   logical :: DoUseScb = .true.
  
@@ -94,7 +90,15 @@ module ModRamParams
   character(len=200) :: StrRamDescription='None'     ! Descript. of simulation
  
   logical :: IsStarttimeSet=.false.  ! True if #STARTTIME used in standalone.
- 
+
+  ! Plasmasphere Model Parameters 
+  logical :: DoUsePlasmasphere = .false.
+  character(len=100) :: PlasmasphereModel = 'Carpenter' ! Name of plasmasphere model to use
+  character(len=100) :: TauCalculation = 'Analytic'     ! Name of method for calculating plasmasphere refilling time
+
+  ! Coulomb Collision Parameters
+  logical :: DoUseCoulomb = .false.
+
   character(len=4) :: NameBoundMag = 'DIPL'
   character(len=6) :: InnerMag, OuterMag
  

--- a/src/ModRamPlasmasphere.f90
+++ b/src/ModRamPlasmasphere.f90
@@ -3,31 +3,176 @@ MODULE ModRamPlasmasphere
 
   implicit none
   real(DP), parameter :: MHP=1.67e-24, MOP=2.67e-23
+  real(DP) :: R, DAY, HOUR
 
   contains
 !==================================================================================================
-  subroutine CARPENTER(KpMax,day,R)
+  subroutine plasmasphere(dt)
+     use ModRamParams,    ONLY: PlasmasphereModel
+     use ModRamTiming,    ONLY: TimeRamNow
+     use ModRamVariables, ONLY: Kp
+
+     real(DP), intent(in) :: dt
+
+     integer  :: nmonth, iapda, isdate
+     real(DP) :: f107_1au, f107_pd, f107_81, f107_365, RZ(3), IG(3), rsn, IAPO(7)
+
+     ! Need total number of days from TimeRamNow
+     DAY = TimeRamNow%iMonth*30 + TimeRamNow%iDay
+     HOUR = TimeRamNow%iHour + TimeRamNow%iMinute/60.0 + TimeRamNow%iSecond/3600.0
+
+     ! These read in the ig_rz and apf107 files and compute values needed by iri and msis
+     CALL TCON(TimeRamNow%iYear,TimeRamNow%iMonth,TimeRamNow%iDay,DAY,RZ,IG,rsn,nmonth)
+     R = Rz(3)
+
+     select case(trim(PlasmasphereModel))
+        case('Carpenter')
+           call CARPENTER(Kp) ! Need to calculate last X hour Kp max
+
+        case('Transport')
+           ! Get AP and F10.7 information for IRI and MSIS models
+           CALL APF_ONLY(TimeRamNow%iYear,TimeRamNow%iMonth,TimeRamNow%iDay,f107_1au,f107_pd,f107_81,f107_365,iapda,isdate)
+           CALL APFMSIS(isdate, HOUR, IAPO)
+
+           ! Compute the ExB velocities
+           call velocity
+
+           ! Compute the refilling constant
+           call TauFill(IAPO, f107_1au, Kp)
+
+           ! Transport Plasmasphere Flux
+           call transport(dt)
+
+        case default
+           call CON_STOP('Unrecognized plasmasphere model - '//trim(PlasmasphereModel))
+
+     end select
+
+  end subroutine plasmasphere
+
+!==================================================================================================
+  subroutine transport(dt)
+     use ModRamGrids, ONLY: nR, nT
+     use ModRamVariables, ONLY: uL, uT, necr, tau, Lz
+     real(DP), intent(in) :: dt
+
+     integer  :: i, j, N, sgn, nX
+     real(DP) :: X, FUP, R, LIMITER, CORR, spp, source, loss
+
+     real(DP), allocatable :: CFL(:), xNE(:), xBND(:)
+
+     nX = max(nR,nT)
+     allocate(CFL(0:nX), xBND(0:nX), xNE(0:nX+2))
+
+     !select case(TransportModel)
+     !  case('superbee')
+     ! Advect Radial
+     do j = 1, nT
+       CFL(1:nR) = uL(:,j)*dt
+       CFL(0)    = CFL(1)
+       xNE(1:nR) = necr(:,j)
+       xNE(0)    = xNE(1)
+       xNE(nR+1) = 1._dp
+       xNE(nR+2) = 1._dp
+       do i = 1, nR
+          sgn = 1
+          if (CFL(i) < 0._dp) sgn = -1
+          X = xNE(i+1) - xNE(i)
+          FUP = 0.5*(xNE(i+1) + xNE(i) - sgn*X)
+          if (abs(X) < 1e-15) then
+             XBND(i) = FUP
+          else
+             N = i + 1 - sgn
+             R = (xNE(N) - xNE(N-1))/X
+             if (R < 0._dp) then
+                xBND(i) = FUP
+             else
+                LIMITER = max(min(2._dp*R,1._dp),min(R,2._dp))
+                CORR = 0.5*(CFL(i) - sgn)*X
+                xBND(i) = FUP - LIMITER*CORR
+             endif
+          endif
+       enddo
+       xBND(0) = xBND(1)
+       do i = 1, nR
+          necr(i,j) = necr(i,j) - (CFL(i)*xBND(i) - CFL(i-1)*xBND(i-1))
+          if (necr(i,j) < 0._dp) necr(i,j) = 1E-15
+       enddo
+     enddo
+   
+     ! Advect Azimuthal
+     do i = 1, nR
+        CFL(1:nT) = uT(:,i)*dt
+        CFL(0)    = CFL(nT-1)
+        xNE(1:nT) = necr(i,:)
+        xNE(0)    = xNE(nT-1)
+        xNE(nT+1) = xNE(2)
+        xNE(nT+2) = xNE(3)
+        do j = 1, nT
+           sgn = 1
+           if (CFL(j) < 0._dp) sgn = -1
+           X = xNE(j+1) - xNE(j)
+           FUP = 0.5*(xNE(j+1) + xNE(j) - sgn*X)
+           if (abs(X) < 1e-15) then
+              XBND(i) = FUP
+           else
+              N = j + 1 - sgn
+              R = (xNE(N) - xNE(N-1))/X
+              if (R < 0._dp) then
+                 xBND(j) = FUP
+              else
+                 LIMITER = max(min(2._dp*R,1._dp),min(R,2._dp))
+                 CORR = 0.5*(CFL(j) - sgn)*X
+                 xBND(j) = FUP - LIMITER*CORR
+              endif
+           endif
+        enddo
+        xBND(0) = xBND(nT-1)
+        do j = 1, nT
+           necr(i,j) = necr(i,j) - (CFL(j)*xBND(j) - CFL(j-1)*xBND(j-1))
+           if (necr(i,j) < 0._dp) necr(i,j) = 1E-15
+        enddo
+     enddo
+   
+     ! Fill and/or empty
+     do i = 1, nR
+        spp = saturation(Lz(i))
+        do j = 1, nT
+           if (necr(i,j) < spp) then
+              source = (spp - necr(i,j))/tau(i,j)
+              necr(i,j) = necr(i,j) + source*dt
+           elseif (necr(i,j) > spp) then
+             ! For now we will have a fixed loss rate of 1.5 days
+             loss = 0._dp !necr(i,j)/(1.5*24.0*3600.0)
+             necr(i,j) = necr(i,j) - loss*dt
+           endif
+        enddo
+     enddo
+
+     !end select
+     deallocate(CFL, xBND, xNE)
+  
+  end subroutine transport
+
+!==================================================================================================
+  subroutine CARPENTER(KpMax)
      use ModRamConst,     ONLY: PI
      use ModRamGrids,     ONLY: nR, nT
      use ModRamVariables, ONLY: Lz, MLT, NECR
 
      implicit none
 
-     real(DP), intent(in) :: KpMax, R, day
+     real(DP), intent(in) :: KpMax
 
      integer,  parameter :: iterMax = 40
      real(DP), parameter :: iterAcc = 0.025
 
      integer  :: i, j, iter, iErr
-     real(DP) :: T, L, C1, C2, X, XL, XD, XR, XT, XN, SPS, PPS, LPPO, LPPI, DX, Y
+     real(DP) :: T, L, C1, C2, X, XN, SPS, PPS, LPPO, LPPI, DX, Y
      real(DP), dimension(2) :: LPP, F
  
-
-
      ! Set input dependent variables
      LPPI = 5.6-0.46*KPMAX
-     XD   = 0.15*(COS(2.*PI*(DAY+9)/365.)-0.5*COS(4.*PI*(DAY+9)/365.))
-     XR   = 0.00127*R-0.0635
 
      ! Set initial values
      LPP(1) = LPPI
@@ -61,9 +206,7 @@ MODULE ModRamPlasmasphere
 
         ! Find LPPO for given MLT (between LPP(1) and LPP(2))
         do i = 1, 2
-           XL = -0.3145*LPP(i)+3.9043
-           XT = XL+(XD+XR)*EXP(-(LPP(i)-2.)/1.5)
-           SPS = 10**XT
+           SPS = saturation(LPP(i))
            PPS = SPS*10.**((LPPI-LPP(i))/X)
            Y = 1. + (C1+C2*T)*LPP(i)**(-4.5) - EXP((2.-LPP(i))/10.)
            F(i) = Y - PPS
@@ -85,9 +228,7 @@ MODULE ModRamPlasmasphere
               iter = iter + 1
               DX = DX*0.5
               LPP(2) = LPPO + DX
-              XL = -0.3145*LPP(2)+3.9043
-              XT = XL+(XD+XR)*EXP(-(LPP(2)-2.)/1.5)
-              SPS = 10**XT
+              SPS = saturation(LPP(2))
               PPS = SPS*10.**((LPPI-LPP(2))/X)
               Y = 1. + (C1+C2*T)*LPP(2)**(-4.5) - EXP((2.-LPP(2))/10.)
               F(2) = Y - PPS
@@ -100,9 +241,7 @@ MODULE ModRamPlasmasphere
         DO i=1,nR
            L = Lz(i)
            ! Saturated Plasmasphere Segment
-           XL = -0.3145*L+3.9043
-           XT = XL+(XD+XR)*EXP(-(L-2.)/1.5)
-           SPS = 10**XT
+           SPS = saturation(L)
            ! Plasmapause segment
            PPS = SPS*10.**((LPPI-L)/X)
            IF (L <= LPPI) THEN
@@ -135,7 +274,8 @@ MODULE ModRamPlasmasphere
         integer i
         save
 
-        a = (1. + 250./RE_km)
+        !a = (1. + 250./RE_km)
+        a = 1._dp
         do i = 1, nR
             x = a/Lz(i)
             flux_volume(i,:) = (32./35.) * Lz(i)**4 * sqrt(1. - x) &
@@ -146,42 +286,133 @@ MODULE ModRamPlasmasphere
     end subroutine volume_dipole
 
 !============================================================================
+    function saturation(L)
+      use ModRamConst, ONLY: PI
+
+      real(DP), intent(in) :: L
+      real(DP) :: saturation, XT, XD, XR, XL
+
+      XD   = 0.15*(COS(2.*PI*(DAY+9)/365.)-0.5*COS(4.*PI*(DAY+9)/365.))
+      XR   = 0.00127*R-0.0635
+      XL = -0.3145*L+3.9043
+      XT = XL+(XD+XR)*EXP(-(L-2.)/1.5)
+      saturation = 10**XT
+
+    end function saturation
+
+!============================================================================
 !
-!  TauFill()  --  calculate refilling time constants (from ionospheric fluxes)
+!  TauFill()  --  calculate refilling time constants
 !
-    subroutine TauFill(day, R, ap, f10p7, Kp)
-        use ModRamParams,    ONLY: useFixedTau
+    subroutine TauFill(ap, f10p7, Kp)
+        use ModRamParams,    ONLY: TauCalculation
         use ModRamConst,     ONLY: RE_cm
         use ModRamGrids,     ONLY: nR, nT
-        use ModRamVariables, ONLY: tau, flux_volume, gdLat, gdLon, nECR
-        
-        use ModIoUnit, ONLY: UnitTmp_
+        use ModRamVariables, ONLY: tau, flux_volume, smLat, smLon, nECR, xRAM, &
+                                   yRAM, zRAM, Lz, Phi
+        use ModRamTiming,    ONLY: TimeRamNow
 
+        use ModIoUnit,      ONLY: UnitTmp_
+        use ModTimeConvert, ONLY: n_day_of_year
+
+        use nrtype, ONLY: pi_d
         implicit none
 
-        real(DP), intent(in) :: day, R, ap, f10p7, Kp
+        real(DP), intent(in) :: ap(7), f10p7, Kp
 
-        real(DP) :: flux
-        integer  :: i, j
+        real(DP) :: flux, lat, lon, xGSM, yGSM, zGSM, xGEO, yGEO, zGEO, gdLat, gdLon
+        integer  :: i, j, iYear, iMonth, iDay, iHour, iMins, iSec, iDoY
+        real(DP) :: MinVolume, MinL, FillDays, LFactor, TFactor
+        integer :: MinLocation(2)
 
-        if(useFixedTau) then  ! vania addition, Jan 1997
-           open(UnitTmp_,file='newtau.dat',status='old')
-           do i=1,nR
-              read(UnitTmp_,*) (tau(i,j),j=0,nT)
-           enddo
-           close(UnitTmp_)
-        else
-        call CARPENTER(Kp,day,R) ! This initializes ne 
+        call volume_dipole()     ! This initializes flux_volume, change to SCB flux tube volume
 
-           do j = 1, nT
+        select case(trim(TauCalculation))
+
+           case('Test')
+              FillDays = 4.5
+              MinVolume = minval(flux_volume(:,:))
+              MinLocation = minloc(flux_volume(:,:))
+              MinL = Lz(MinLocation(1))
               do i = 1, nR
-                 call fluxInf(gdLat(i,j),gdLon(i,j),f10p7,ap,R,flux)
-                 tau(i,j) = nECR(i,j)*flux_volume(i,j)*RE_cm/flux ! This return flux in units of cm^2/s
-              end do
-           end do
-           tau = tau/3600. ! Convert to hours
+                 LFactor = 1._dp !(1._dp/Lz(i))**(0.3)
+                 do j = 1, nT
+                    TFactor = 1._dp !sin(Phi(j))
+                    flux = 2._dp*LFactor*TFactor*MinVolume*MinL*saturation(MinL)/(FillDays*24._dp*3600._dp)
+                    tau(i,j) = saturation(Lz(i))*flux_volume(i,j)/flux
+                 enddo
+              enddo
 
-        endif
+              iYear   = TimeRamNow%iYear
+              iMonth  = TimeRamNow%iMonth
+              iDay    = TimeRamNow%iDay
+              iHour   = TimeRamNow%iHour
+              iMins   = TimeRamNow%iMinute
+              iSec    = TimeRamNow%iSecond
+              iDoY    = n_day_of_year(iYear,iMonth,iDay)
+              call RECALC_08(iYear,iDoY,iHour,iMins,iSec,-400._dp,0._dp,0._dp)
+
+              do i = 1, nR
+
+                 do j = 1, nT
+                    CALL SMGSW_08(xRAM(1,i,j),yRAM(1,i,j),abs(zRAM(1,i,j)),xGSM,yGSM,zGSM,1)
+                    CALL GEOGSW_08(xGEO,yGEO,zGEO,xGSM,yGSM,zGSM,-1)
+                    gdLat = pi_d/2.0 - acos(zGEO/sqrt(xGEO**2+yGEO**2+zGEO**2))
+                    gdLon = atan2(yGEO,xGEO)
+                    call fluxInf(gdLat*180/pi_d,gdLon*180/pi_d,f10p7,ap,flux)
+                    tau(i,j) = (saturation(Lz(i))*flux_volume(i,j)*RE_cm/flux)
+                 end do
+
+              end do
+
+           case('Fixed')  ! vania addition, Jan 1997
+              open(UnitTmp_,file='newtau.dat',status='old')
+              do i=1,nR
+                 read(UnitTmp_,*) (tau(i,j),j=0,nT)
+              enddo
+              close(UnitTmp_)
+        
+           case('Analytic')
+              ! Analytical approximation for refilling time constants taken from DGCPM
+              FillDays = 4.5
+              MinVolume = minval(flux_volume(:,:))
+              MinLocation = minloc(flux_volume(:,:))
+              MinL = Lz(MinLocation(1))
+              do i = 1, nR
+                 LFactor = 1._dp !(1._dp/Lz(i))**(0.3)
+                 do j = 1, nT
+                    TFactor = 1._dp !sin(Phi(j))
+                    flux = 2._dp*LFactor*TFactor*MinVolume*MinL*saturation(MinL)/(FillDays*24._dp*3600._dp)
+                    tau(i,j) = saturation(Lz(i))*flux_volume(i,j)/flux
+                 enddo
+              enddo
+
+           case('Rasmussen')
+              ! Uses Ionospheric Fluxes to calculate a refilling time constant
+              iYear   = TimeRamNow%iYear
+              iMonth  = TimeRamNow%iMonth
+              iDay    = TimeRamNow%iDay
+              iHour   = TimeRamNow%iHour
+              iMins   = TimeRamNow%iMinute
+              iSec    = TimeRamNow%iSecond
+              iDoY    = n_day_of_year(iYear,iMonth,iDay)
+              call RECALC_08(iYear,iDoY,iHour,iMins,iSec,-400._dp,0._dp,0._dp)
+   
+              do i = 1, nR
+                 do j = 1, nT
+                    CALL SMGSW_08(xRAM(1,i,j),yRAM(1,i,j),abs(zRAM(1,i,j)),xGSM,yGSM,zGSM,1)
+                    CALL GEOGSW_08(xGEO,yGEO,zGEO,xGSM,yGSM,zGSM,-1)
+                    gdLat = pi_d/2.0 - acos(zGEO/sqrt(xGEO**2+yGEO**2+zGEO**2))
+                    gdLon = atan2(yGEO,xGEO)
+                    call fluxInf(gdLat*180/pi_d,gdLon*180/pi_d,f10p7,ap,flux) ! This return 'flux' in units of cm^2/s
+                    tau(i,j) = saturation(Lz(i))*flux_volume(i,j)*RE_cm/flux
+                 end do
+              end do
+
+           case default
+              call CON_STOP('Unrecognized filling parameter method - '//trim(TauCalculation))
+
+        end select
 
         return
     end subroutine TauFill
@@ -190,7 +421,7 @@ MODULE ModRamPlasmasphere
 !
 !  fluxInf()  --  calculate maximum ionospheric flux at 1000 km
 !
-    subroutine fluxInf(lat,lon,f10p7,ap_,Rs,flux)
+    subroutine fluxInf(lat,lon,f10p7,ap_,flux)
       use ModRamConst,  ONLY: KB, RE_cm, RE_km
       use ModRamTiming, ONLY: TimeRamNow
 
@@ -199,7 +430,7 @@ MODULE ModRamPlasmasphere
       implicit none
 
       real(DP), intent(inout) :: flux
-      real(DP), intent(in)    :: lat, lon, f10p7, ap_, Rs
+      real(DP), intent(in)    :: lat, lon, f10p7, ap_(7)
 
       integer  :: iyd, iMass, iyear, imonth, iday, ihour, imin, isec, doy
       real(DP) :: sec, hours, sLT
@@ -223,18 +454,6 @@ MODULE ModRamPlasmasphere
       hours = sec/3600.
       mmdd  = -doy ! Since day is day-of-year, I store this as a negative number in mmdd
 
-!        AP - MAGNETIC INDEX(DAILY) OR WHEN SW(9)=-1. :
-!           - ARRAY CONTAINING:
-!             (1) DAILY AP
-!             (2) 3 HR AP INDEX FOR CURRENT TIME
-!             (3) 3 HR AP INDEX FOR 3 HRS BEFORE CURRENT TIME
-!             (4) 3 HR AP INDEX FOR 6 HRS BEFORE CURRENT TIME
-!             (5) 3 HR AP INDEX FOR 9 HRS BEFORE CURRENT TIME
-!             (6) AVERAGE OF EIGHT 3 HR AP INDICIES FROM 12 TO 33 HRS
-!                 PRIOR TO CURRENT TIME
-!             (7) AVERAGE OF EIGHT 3 HR AP INDICIES FROM 36 TO 57 HRS
-!                 PRIOR TO CURRENT TIME
-! Since I don't have these let's just fill up ap with a constant value
       ap(1:7) = ap_
 
 ! Standard IRI 2012 run
@@ -246,6 +465,7 @@ MODULE ModRamPlasmasphere
       JF(23) = .false.
       JF(28:30) = .false.
       JF(33) = .false.
+      JF(34) = .false. ! Turn off messages
       JF(35) = .false.
 
 
@@ -276,7 +496,8 @@ MODULE ModRamPlasmasphere
       Ho  = KB*Tn/(MOP*g)
       Hc = HOp*Ho / (HOp - Ho)
       Hp = ( HOp*Ho / (HOp + Ho) ) / 1.e5
-      alt0 = altr - Hp*log( (2.e19/(nOp*nO)) * (Ti/Hc)**2 )
+      alt0 = altr - Hp*log( (7.5e18/(nOp*nO)) * (Ti/Hc)**2 )
+      ! Changed 2.0e19 to 7.5e18 as mentioned in Rasmussen et al. 1992 -ME
 
       ! Get temperature at alt0
       iMass = 0
@@ -301,7 +522,11 @@ MODULE ModRamPlasmasphere
       flux = 2.5e-11*sqrt(Tn)*nH*nOp*HOp
 
       ! Extrapolate flux from alt0 t0 1000 km
-      flux = flux * ( (RE_km+alt0)/(RE_km+1000.) )**3
+      !flux = flux * ( (RE_km+alt0)/(RE_km+1000.) )**3
+      ! Why???? Both Richards and Torr (1985) and Rasmussen et al. (1992) say to
+      ! just use flux at alt0 (z0 in their papers). Since the equations
+      ! presented here are basically ver-batim from those papers we will not
+      ! scale the value -ME
 
       return
     end subroutine fluxInf
@@ -314,30 +539,39 @@ MODULE ModRamPlasmasphere
         use ModRamConst,     ONLY: PI, Re
         use ModRamGrids,     ONLY: nR, nT
         use ModRamTiming,    ONLY: DTs
-        use ModRamVariables, ONLY: Lz, MLT, VT, BNES, MDR, DPHI, uL, uT
+        use ModRamVariables, ONLY: Lz, RLz, MLT, VT, BNES, MDR, DPHI, uL, uT, EIP
 
         implicit none
 
-        integer  :: i, j, j1
-        real(DP) :: facL, facT
+        integer  :: i, j, jp, jm
+        real(DP) :: facL, facT, facV, temp
 
 !        A = 7.05e-6 / (1. - 0.159*Kp + 0.0093*Kp*Kp)**3
-        facL = 3600. / RE                                ! per hour
-        facT = 3600. * (24.0/(2.*PI)) / RE                ! per hour
+        facL = 1._dp / RE                         ! per second
+        facT = (24.0/(2.*PI)) / RE                ! per second
+        facV = 0.5/DPHI/MDR
 
-        do i = 1, nR+1
+        do i = 1, nR
            do j = 1, nT
-             j1=j
-             if (j.eq.0) j1=nt
-             uL(i,j) = (VT(i,j1-1)-VT(i,j+1))/2/RE/Lz(i)/BNES(i,j)/DPHI*facL
+             jp = j+1
+             jm = j-1
+             if (j.eq.1) jm = nt-1
+             if (j.eq.nT) jp = 2
+             !uL(i,j) = (VT(i,jm)-VT(i,jp))/2/RE/Lz(i)/BNES(i,j)/DPHI*facL
+             uL(i,j) = facV*(VT(I,Jm) - VT(I,Jp))/BNES(I,J)/RLZ(i)
             end do
         end do
+        uL(:,1) = uL(:,nT)
 
         do j = 1, NT
-           do i = 1, NR
-             ut(j,i) = (VT(i+1,j)-VT(i-1,j))/2/Lz(i)/BNES(i,j)/MDR/RE*facT
+           !ut(j,1) = (VT(2,j)-VT(1,j))/Lz(1)/BNES(1,j)/MDR/RE*facT
+           ut(j,1) = 2._dp*facV*(VT(2,j) - VT(1,j))/BNES(1,j)/RLz(i)
+           do i = 2, NR
+             !ut(j,i) = (VT(i+1,j)-VT(i-1,j))/2/Lz(i)/BNES(i,j)/MDR/RE*facT
+             ut(j,i) = facV*(VT(i+1,j) - VT(i-1,j))/BNES(i,j)/RLz(i)
            end do
         end do
+        uT(1,:) = uT(nT,:)
 
         return
     end subroutine velocity

--- a/src/ModRamScb.f90
+++ b/src/ModRamScb.f90
@@ -144,7 +144,7 @@ Module ModRamScb
   
     use ModRamVariables, ONLY: FNHS, FNIS, BNES, HDNS, dBdt, dHdt, &
                                dIdt, dIbndt, BOUNHS, BOUNIS, EIR, EIP, flux_volume, &
-                               LZ, MU, MLT, PAbn, PA, DL1, outsideMGNP
+                               LZ, MU, MLT, PAbn, PA, DL1, outsideMGNP, xRAM, yRAM, zRAM
     use ModRamTiming,    ONLY: TimeRamElapsed, TOld, TimeRamNow
     use ModRamConst,     ONLY: b0dip
     use ModRamParams,    ONLY: NameBoundMag, verbose, checkMGNP, integral_smooth, densityMode
@@ -192,7 +192,7 @@ use ModTimeConvert, ONLY: n_day_of_year
     REAL(DP), ALLOCATABLE :: bbx(:), bby(:), bbz(:), xx(:), yy(:), zz(:), cval(:)
     REAL(DP), ALLOCATABLE :: BNESPrev(:,:), FNISPrev(:,:,:), BOUNISPrev(:,:,:), &
                              FNHSPrev(:,:,:), BOUNHSPrev(:,:,:), dHbndt(:,:,:)
-    REAL(DP), ALLOCATABLE :: xRAM(:,:,:), yRAM(:,:,:), zRAM(:,:,:), bRAM(:,:,:)
+    REAL(DP), ALLOCATABLE :: bRAM(:,:,:)
     REAL(DP) :: scalingI, scalingH, scalingD, I_Temp, H_Temp, D_Temp
  
     REAL(DP), ALLOCATABLE :: kernel(:,:), output(:,:)
@@ -223,8 +223,7 @@ call RECALC_08(TimeRamNow%iYear,n_day_of_year(TimeRamNow%iYear,TimeRamNow%iMonth
              r0(nR,nT), bfMirror(nR,nT,nPa), yI(nR,nT,NPA), yH(nR,nT,NPA), yD(nR,nT,NPA), &
              BNESPrev(nR+1,nT), FNHSPrev(nR+1,nT,nPa),FNISPrev(nR+1,nT,nPa), &
              BOUNISPrev(nR+1,nT,nPa), BOUNHSPrev(nR+1,nT,nPa), dHbndt(nR+1,nT,nPa), &
-             xRAM(nthe,nR,nT),yRAM(nthe,nR,nT),zRAM(nthe,nR,nT),bRAM(nthe,nR,nT), &
-             density(nthe,nR,nT))
+             bRAM(nthe,nR,nT), density(nthe,nR,nT))
     !!!
 
     h_Cart = 0._dp; I_Cart = 0._dp
@@ -637,7 +636,7 @@ call RECALC_08(TimeRamNow%iYear,n_day_of_year(TimeRamNow%iYear,TimeRamNow%iMonth
 
     DEALLOCATE(length,r0,distance,yI,yH,yD,bfmirror,bbx,bby,bbz,cVal,xx,yy,zz, &
                BNESPrev,FNISPrev,ScaleAt,BOUNISPrev,FNHSPrev,BOUNHSPrev,dHbndt)
-    DEALLOCATE(xRAM,yRAM,zRAM,bRAM,outsideSCB,density)
+    DEALLOCATE(bRAM,outsideSCB,density)
  
     RETURN
   

--- a/src/ModRamVariables.f90
+++ b/src/ModRamVariables.f90
@@ -19,7 +19,7 @@ Module ModRamVariables
 
   ! ModRamPlasmasphere Variables
   real(DP), ALLOCATABLE :: flux_volume(:,:), uL(:,:), uT(:,:), tau(:,:), &
-                           gdLon(:,:), gdLat(:,:)
+                           smLon(:,:), smLat(:,:), xRAM(:,:,:), yRAM(:,:,:), zRAM(:,:,:)
 
 ! UNKNOWN VARIABLES
   real(DP), ALLOCATABLE :: XNE(:,:)

--- a/src/ModRamWPI.f90
+++ b/src/ModRamWPI.f90
@@ -436,7 +436,7 @@ MODULE ModRamWPI
   SUBROUTINE WAVELO(S)
 
     use ModRamMain,      ONLY: DP
-    use ModRamParams,    ONLY: DoUsePlane_SCB
+    use ModRamParams,    ONLY: DoUsePlasmasphere
     use ModRamGrids,     ONLY: NE, NR, NT, NPA
     use ModRamTiming,    ONLY: Dts
     use ModRamVariables, ONLY: F2, KP, LZ, IP1, IR1, EKEV, NECR, WALOS1, &
@@ -456,11 +456,9 @@ MODULE ModRamWPI
     IF (KP.GE.4.0) Bw=100.                                 ! pT
     Kpmax=KP  ! need Kpmax from previous 12 hrs, TO FIX!!!
     DO J=1,NT
-      J1=int((J-1)*IP1,kind=4)
       RLpp(J)=5.39-0.382*KPmax  ! PP from Moldwin et al. [2002]
       DO I=2,NR
-        I1=int((I-2)*IR1+3,kind=4)
-        IF (DoUsePlane_SCB.and.NECR(I1,J1).gt.50.) RLpp(J)=LZ(I)
+        IF (DoUsePlasmasphere.and.NECR(I,J).gt.50.) RLpp(J)=LZ(I)
       ENDDO
     ENDDO
 


### PR DESCRIPTION
Added a plasmasphere model that evolves the cold electron population by
using ExB transportation combined with loss and refilling terms. In
order to differentiate between using the Carpenter and Anderson model vs
the new model a new parameter was created for the PARAM file
(#PLASMASPHERE). The format is;
    #PLASMASPHERE
    T                    DoUsePlasmasphere (T/F)
    Transport       PlasmasphereModel (Carpenter/Transport)
    Rasmussen    RefillingTau                (Fixed/Analytic/Rasmussen)

The RefillingTau parameter can read from a file (Fixed), can be
calculated analytically using the method in DGCPM (Analytic), or can be
calculated using the Rasmussen model (Rasmussen). Note that for all
three versions the loss time scale is currently fixed. By default the
plasmasphere is turned off.

CAVEATS:
 - The new transport model has not been thoroughly tested and is in a
   beta state
 - The refilling rates being calculated by the models have only
   been loosely compared against observed refilling rates