### PR TITLE
Correct dimensionality of omniflux in virtual satellite files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,7 +364,7 @@ test4_check:
 	ncrcat ${TESTDIR4}/output_ram/sat1_d20130317_t000000.nc       \
                ${TESTDIR4}/output_ram/sat1_d20130317_t001000.nc       \
                ${TESTDIR4}/output_ram/sat1.nc
-	ncdump -v "FluxH+","B_xyz" ${TESTDIR4}/output_ram/sat1.nc     \
+	ncdump -v "Flux_H","B_xyz" ${TESTDIR4}/output_ram/sat1.nc     \
                | sed -e '1,/data:/d' >                                \
                ${TESTDIR4}/output_ram/sat1.test        
 	${SCRIPTDIR}/DiffNum.pl -b -a=1e-9                            \
@@ -374,7 +374,7 @@ test4_check:
 	ncrcat ${TESTDIR4}/output_ram/sat2_d20130317_t000000.nc       \
                ${TESTDIR4}/output_ram/sat2_d20130317_t001000.nc       \
                ${TESTDIR4}/output_ram/sat2.nc
-	ncdump -v "FluxH+","B_xyz" ${TESTDIR4}/output_ram/sat2.nc     \
+	ncdump -v "Flux_H","B_xyz" ${TESTDIR4}/output_ram/sat2.nc     \
                | sed -e '1,/data:/d' >                                \
                ${TESTDIR4}/output_ram/sat2.test
 	${SCRIPTDIR}/DiffNum.pl -b -a=1e-9                            \

--- a/src/ModRamSats.f90
+++ b/src/ModRamSats.f90
@@ -400,7 +400,7 @@ module ModRamSats
          ! OMNIDIRECTIONAL FLUX
     do iS = 1, nS
        iStatus = nf90_def_var(iFileID, 'omni'//species(iS)%s_code, nf90_float, &
-                              (/iEnDim, iPaDim, iTimeDim/), iOFluxVar)
+                              (/iEnDim, iTimeDim/), iOFluxVar)
        iStatus = nf90_put_att(iFileID, iOFluxVar, 'title', &
             'Energy and pitch-angle dependent particle flux at spacecraft: '//species(iS)%s_code)
        iStatus = nf90_put_att(iFileID, iOFluxVar, 'units', '1/cm2/s/keV')


### PR DESCRIPTION
Closes #68 

- Changes the dimension of the omniflux variable in the output netCDFs to address #68 
- Fixes the Makefile so that test4 runs (it had ncdump looking for "FluxH+" which is no longer in these files)

Submitted as a draft PR as test4 is failing locally. @Pheosics - can I ask you to look into why test4 is failing here?