### PR TITLE
Enabled nitrogen as percentage of oxygen runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ rundir:
 	cp input/ne_full.dat ${RUNDIR}/
 	cp input/initialization.nc ${RUNDIR}/IM/
 	cp input/QinDenton_20130317_1min.txt ${RUNDIR}/IM/
+	cp input/NitrogenCrossSections.dat ${RUNDIR}/IM/
 	cp input/AEindex.txt ${RUNDIR}/
 	cd ${RUNDIR}; \
 	ln -s ../input/bav_diffcoef_chorus_rpa_Kp*.PAonly.dat .
@@ -86,7 +87,8 @@ rundir:
 		mv Input_git/omni.txt ../;		    \
 		mv Input_git/*geomlt*.txt input_ram/; \
                 mv initialization.nc input_ram/;            \
-		mv QinDenton_20130317_1min.txt input_scb/;
+		mv QinDenton_20130317_1min.txt input_scb/;  \
+		mv NitrogenCrossSections.dat input_ram/;
 	@(if [ "$(STANDALONE)" != "NO" ]; then \
 		cd ${RUNDIR} ; \
 		cp ${IMDIR}/Param/PARAM.in.default ./PARAM.in; \

--- a/Param/PARAM.in.default
+++ b/Param/PARAM.in.default
@@ -69,6 +69,18 @@ F			doUseKpDiff		! Whether to use KP based diffusion coefficients for wave parti
 ***********************************************
 
 ***************** RAM BLOCK *******************
+#SPECIES
+4			nSpecies		! Number of species to use in run
+_H _O He _e		NameVar			! List of the species to use, species codes are found in ModRamSpecies.f90
+F			FixedComposition	! If false, will use the Young et al. composition to split ions in boundary file
+40			PercentComp		! If FixedComposition is true, apply this percentage to the first species (_H)
+40			PercentComp		! If FixedComposition is true, apply this percentage to the second species (_O)
+20			PercentComp		! If FixedComposition is true, apply this percentage to the third species (He)
+100			PercentComp		! If FixedComposition is true, apply this percentage to the fourth species (_e)
+
+#NITROGEN_PERCENT
+00			OpercentN		! Percentage of oxygen converted to nitrogen if using nitrogen
+
 #MULTISPECIESBCS
 F                       DoMultiSpeciesBcs       ! Whether to use boundary flux files that are split into multiple species (H+, He, O)
 T                       DoElectrons             ! Whether to run electrons

--- a/src/IM_set_parameters.f90
+++ b/src/IM_set_parameters.f90
@@ -5,7 +5,7 @@
 subroutine IM_set_parameters
 
 !!!!! Module Variables
-  use ModRamMain,    ONLY: PathRestartIn, nIter
+  use ModRamMain,    ONLY: PathRestartIn, nIter, DP
   use ModRamGrids,   ONLY: nS, NEL, NTL, NR, NT, NE, NPA, NameVar
   use ModRamVariables, ONLY: composition
   use ModRamTiming,  ONLY: TimeRamElapsed, TimeRamStart, TimeRamRealStart, &
@@ -32,6 +32,7 @@ subroutine IM_set_parameters
   integer :: i, nChar, nrIn, ntIn, neIn, npaIn
   logical :: TempLogical
   logical :: StopCommand, IsStopTimeSet
+  real(DP) :: TempReal
   character(len=100) :: StringLine, NameCommand, RestartFile
   character(len=*), parameter  :: NameSub = 'IM_set_parameters'
   StopCommand = .false.
@@ -99,9 +100,14 @@ subroutine IM_set_parameters
         if (FixedComposition) then
            allocate(composition(nS))
            do i=1,nS
-              call read_var('Composition',composition(i))
+              call read_var('Composition',TempReal)
+              composition(i) = TempReal/100
            enddo
         endif
+
+     case('#NITROGEN_PERCENT')
+        call read_var('NitrogenPercent', TempReal)
+        OpercentN = TempReal/100
 
      case('#FLAT_INITIALIZATION')
         InitializeOnFile = .false.

--- a/src/IM_set_parameters.f90
+++ b/src/IM_set_parameters.f90
@@ -107,7 +107,7 @@ subroutine IM_set_parameters
 
      case('#NITROGEN_PERCENT')
         call read_var('NitrogenPercent', TempReal)
-        OpercentN = TempReal/100
+        OfracN = TempReal/100
 
      case('#FLAT_INITIALIZATION')
         InitializeOnFile = .false.

--- a/src/ModRamBoundary.f90
+++ b/src/ModRamBoundary.f90
@@ -265,7 +265,7 @@ end subroutine get_geomlt_flux
       select case(species(S)%s_name)
       case ("Electron")
         call get_geomlt_flux('elec', FluxLanl)
-      case ("Hydrogen", "OxygenP1", "HeliumP1")
+      case ("Hydrogen", "OxygenP1", "HeliumP1", "Nitrogen")
         call get_geomlt_flux('prot', FluxLanl)
       case default
         FluxLanl = 0._dp

--- a/src/ModRamBoundary.f90
+++ b/src/ModRamBoundary.f90
@@ -266,6 +266,8 @@ end subroutine get_geomlt_flux
       case ("Electron")
         call get_geomlt_flux('elec', FluxLanl)
       case ("Hydrogen", "OxygenP1", "HeliumP1", "Nitrogen")
+        ! We assume a fraction of the oxygen is actually nitrogen
+        ! The specific percentage is configurable in the PARAM file
         call get_geomlt_flux('prot', FluxLanl)
       case default
         FluxLanl = 0._dp

--- a/src/ModRamIO.f90
+++ b/src/ModRamIO.f90
@@ -536,7 +536,7 @@ end subroutine read_geomlt_file
     use ModRamMain,      ONLY: DP
     use ModRamGrids,     ONLY: nR, nT, nE, nPA, RadiusMax, RadiusMin, nS
     use ModRamVariables, ONLY: F2, EkeV, Lz, MLT, Pa, PParT, PPerT, species
-    use ModRamParams,    ONLY: InitializationPath
+    use ModRamParams,    ONLY: InitializationPath, OpercentN
 
     use ModRamGSL, ONLY: GSL_Interpolation_2D
     use ModRamNCDF, ONLY: ncdf_check
@@ -613,6 +613,10 @@ end subroutine read_geomlt_file
           iStatus = nf90_get_var(iFileID, iFluxHeVar, iF2(i,:,:,:,:))
        case('OxygenP1')
           iStatus = nf90_get_var(iFileID, iFluxOVar,  iF2(i,:,:,:,:))
+          iF2(i,:,:,:,:) = (1. - OpercentN)*iF2(i,:,:,:,:)
+       case('Nitrogen')
+          iStatus = nf90_get_var(iFileID, iFluxOVar,  iF2(i,:,:,:,:))
+          iF2(i,:,:,:,:) = OpercentN*iF2(i,:,:,:,:)
        case default
           iF2(i,:,:,:,:) = 0._dp
        end select

--- a/src/ModRamIO.f90
+++ b/src/ModRamIO.f90
@@ -536,7 +536,7 @@ end subroutine read_geomlt_file
     use ModRamMain,      ONLY: DP
     use ModRamGrids,     ONLY: nR, nT, nE, nPA, RadiusMax, RadiusMin, nS
     use ModRamVariables, ONLY: F2, EkeV, Lz, MLT, Pa, PParT, PPerT, species
-    use ModRamParams,    ONLY: InitializationPath, OpercentN
+    use ModRamParams,    ONLY: InitializationPath, OfracN
 
     use ModRamGSL, ONLY: GSL_Interpolation_2D
     use ModRamNCDF, ONLY: ncdf_check
@@ -613,12 +613,12 @@ end subroutine read_geomlt_file
           iStatus = nf90_get_var(iFileID, iFluxHeVar, iF2(i,:,:,:,:))
        case('OxygenP1')
           iStatus = nf90_get_var(iFileID, iFluxOVar,  iF2(i,:,:,:,:))
-          iF2(i,:,:,:,:) = (1. - OpercentN)*iF2(i,:,:,:,:)
+          iF2(i,:,:,:,:) = (1. - OfracN)*iF2(i,:,:,:,:)
        case('Nitrogen')
           ! If we want to initialize some nitrogen, we assume that a percentage
           ! of the oxygen in the initialization file is actually nitrogen
           iStatus = nf90_get_var(iFileID, iFluxOVar,  iF2(i,:,:,:,:))
-          iF2(i,:,:,:,:) = OpercentN*iF2(i,:,:,:,:)
+          iF2(i,:,:,:,:) = OfracN*iF2(i,:,:,:,:)
        case default
           iF2(i,:,:,:,:) = 0._dp
        end select

--- a/src/ModRamIO.f90
+++ b/src/ModRamIO.f90
@@ -615,6 +615,8 @@ end subroutine read_geomlt_file
           iStatus = nf90_get_var(iFileID, iFluxOVar,  iF2(i,:,:,:,:))
           iF2(i,:,:,:,:) = (1. - OpercentN)*iF2(i,:,:,:,:)
        case('Nitrogen')
+          ! If we want to initialize some nitrogen, we assume that a percentage
+          ! of the oxygen in the initialization file is actually nitrogen
           iStatus = nf90_get_var(iFileID, iFluxOVar,  iF2(i,:,:,:,:))
           iF2(i,:,:,:,:) = OpercentN*iF2(i,:,:,:,:)
        case default

--- a/src/ModRamIndices.f90
+++ b/src/ModRamIndices.f90
@@ -265,9 +265,11 @@ module ModRamIndices
               species(i)%s_comp = 2.*GEXP/(4.+BEXP+2.*GEXP)
             case("OxygenP1")
               Operc = BEXP/(4.+BEXP+2.*GEXP)
+              ! Subtract nitrogen percent from oxygen percent
               species(i)%s_comp = (1-OpercentN)*Operc
             case("Nitrogen")
               Operc = BEXP/(4.+BEXP+2.*GEXP)
+              ! Take a percent of the oxygen composition for nitrogen
               species(i)%s_comp = OpercentN*Operc
             case default
               species(i)%s_comp = 1.0

--- a/src/ModRamIndices.f90
+++ b/src/ModRamIndices.f90
@@ -194,7 +194,7 @@ module ModRamIndices
     ! Use f10.7 according to current day.
     ! Input time format should be floating point used in ModTimeConvert.
     use ModRamGrids,     ONLY: nS
-    use ModRamParams,    ONLY: FixedComposition, OpercentN
+    use ModRamParams,    ONLY: FixedComposition, OfracN
     use ModRamVariables, ONLY: nRawKp, nRawF107, nRawAE, Kp, F107, AE, timeKp, &
                                timeF107, timeAE, rawKp, rawF107, rawAE, species
     use ModRamParams,    ONLY: DoUseEMIC
@@ -266,11 +266,11 @@ module ModRamIndices
             case("OxygenP1")
               Operc = BEXP/(4.+BEXP+2.*GEXP)
               ! Subtract nitrogen percent from oxygen percent
-              species(i)%s_comp = (1-OpercentN)*Operc
+              species(i)%s_comp = (1-OfracN)*Operc
             case("Nitrogen")
               Operc = BEXP/(4.+BEXP+2.*GEXP)
               ! Take a percent of the oxygen composition for nitrogen
-              species(i)%s_comp = OpercentN*Operc
+              species(i)%s_comp = OfracN*Operc
             case default
               species(i)%s_comp = 1.0
           end select

--- a/src/ModRamIndices.f90
+++ b/src/ModRamIndices.f90
@@ -194,7 +194,7 @@ module ModRamIndices
     ! Use f10.7 according to current day.
     ! Input time format should be floating point used in ModTimeConvert.
     use ModRamGrids,     ONLY: nS
-    use ModRamParams,    ONLY: FixedComposition
+    use ModRamParams,    ONLY: FixedComposition, OpercentN
     use ModRamVariables, ONLY: nRawKp, nRawF107, nRawAE, Kp, F107, AE, timeKp, &
                                timeF107, timeAE, rawKp, rawF107, rawAE, species
     use ModRamParams,    ONLY: DoUseEMIC
@@ -207,7 +207,7 @@ module ModRamIndices
     integer,           intent(out):: AENow
     
     integer :: iTime, i
-    real(kind=Real8_) :: dTime, dateNow, BEXP, AHE0, AHE1, GEXP
+    real(kind=Real8_) :: dTime, dateNow, BEXP, AHE0, AHE1, GEXP, Operc
 
     !------------------------------------------------------------------------
     ! NOTE: AS MORE SOURCES ARE ADDED, USE CASE STATEMENTS TO 
@@ -264,9 +264,13 @@ module ModRamIndices
             case("HeliumP1")
               species(i)%s_comp = 2.*GEXP/(4.+BEXP+2.*GEXP)
             case("OxygenP1")
-              species(i)%s_comp = BEXP/(4.+BEXP+2.*GEXP)
-            !case default
-            !  s_comp(i) = 1.0
+              Operc = BEXP/(4.+BEXP+2.*GEXP)
+              species(i)%s_comp = (1-OpercentN)*Operc
+            case("Nitrogen")
+              Operc = BEXP/(4.+BEXP+2.*GEXP)
+              species(i)%s_comp = OpercentN*Operc
+            case default
+              species(i)%s_comp = 1.0
           end select
        enddo
     endif

--- a/src/ModRamParams.f90
+++ b/src/ModRamParams.f90
@@ -89,6 +89,7 @@ module ModRamParams
   logical :: BoundaryFiles = .true.
   real(DP) :: ElectronFluxCap = 1e10
   real(DP) :: ProtonFluxCap = 1e8
+  real(DP) :: OpercentN = 0.
  
   logical :: DoVarDt = .true.                        ! Use variable timestep.
  

--- a/src/ModRamParams.f90
+++ b/src/ModRamParams.f90
@@ -90,8 +90,8 @@ module ModRamParams
   real(DP) :: ElectronFluxCap = 1e10
   real(DP) :: ProtonFluxCap = 1e8
 
-  ! Sets a percentage of oxygen to turn into nitrogen
-  real(DP) :: OpercentN = 0.
+  ! Sets a fraction of oxygen to turn into nitrogen
+  real(DP) :: OfracN = 0.
  
   logical :: DoVarDt = .true.                        ! Use variable timestep.
  

--- a/src/ModRamParams.f90
+++ b/src/ModRamParams.f90
@@ -89,6 +89,8 @@ module ModRamParams
   logical :: BoundaryFiles = .true.
   real(DP) :: ElectronFluxCap = 1e10
   real(DP) :: ProtonFluxCap = 1e8
+
+  ! Sets a percentage of oxygen to turn into nitrogen
   real(DP) :: OpercentN = 0.
  
   logical :: DoVarDt = .true.                        ! Use variable timestep.


### PR DESCRIPTION
These changes allow the user to specify a percentage of oxygen to turn into nitrogen for a given run. This impacts the initialization by turning a given percentage from oxygen to nitrogen, and the flux at the boundary by changing the Young et al. composition percentages. The user specifies the percentage of nitrogen they want by adding 

```
#NITROGEN_PERCENT
20
```
to the PARAM file (for 20 percent oxygen to nitrogen conversion). Note that unless the user also specifies using nitrogen as a species in the PARAM file the conversion will subtract from the oxygen and the composition ratios will no longer add up to 1.

I've also set up the Makefile so that it correctly copies the NitrogenCrossSections to the input directory when making a run directory.