### PR TITLE
Auto-detect NetCDF4 and GSL locations and flags

### DIFF
--- a/Config.pl
+++ b/Config.pl
@@ -17,7 +17,10 @@ our $MakefileDefOrig = 'src/Makefile.def';
 our @Arguments       = @ARGV;
 my  $IsStandalone = 'True';
 my  $DoSetLibs;
+my  $DoAutoGSL;
+my  $DoAutoNCF;
 my  $SchemeUser = 'False';
+sub check_exists;
 
 foreach(@Arguments){
     if(/^-scheme/) {$SchemeUser = 'True';
@@ -58,8 +61,29 @@ foreach(@Arguments){
                     $DoSetLibs = 1;
                     next;
     };
-    if(/^-ncdf=(.*)/)    {$libs{'netcdf'} =$1; $DoSetLibs = 1; next;};
-    if(/^-gsl=(.*)/)     {$libs{'gsl'}    =$1; $DoSetLibs = 1; next;};
+    if(/^-ncdf/) {
+        if(/^-ncdf=(.+)/) {
+            # Value supplied
+            $libs{'netcdf'} =$1;
+        } else {
+            # No value supplied. try to autodetect
+            # Requires nf-config
+            check_exists 'nf-config' or die "$0 requires nf-config";
+            $DoAutoNCF = 1;
+        }
+        $DoSetLibs = 1;
+        next;};
+    if(/^-gsl/) {
+        if(/^-gsl=(.+)/) {
+            $libs{'gsl'} = $1;
+        } else {
+            # No value supplied. try to autodetect
+            # Requires gsl-config
+            check_exists 'gsl-config' or die "$0 requires gsl-config";
+            $DoAutoGSL = 1;
+        }
+        $DoSetLibs = 1;
+        next;};
     if(/^-setlibs/)      {$DoSetLibs = 1;  next;};
 }
 
@@ -73,8 +97,22 @@ $DoSetLibs = 1 if($Install);
 # Set up library locations.
 if($DoSetLibs){
     # Set default library locations unless set by flags.
-    $libs{'netcdf'}=$ENV{NETCDFDIR} unless exists $libs{'netcdf'};
-    $libs{'gsl'}=$ENV{GSLDIR} unless exists $libs{'gsl'};
+    if ($DoAutoNCF) {
+        print "Auto-detecting NetCDF-Fortran location\n";
+        my $npre = `nf-config --prefix`;
+        chomp($npre);
+        $libs{'netcdf'}=$npre;
+    } else {
+        $libs{'netcdf'}=$ENV{NETCDFDIR} unless exists $libs{'netcdf'};
+    }
+    if ($DoAutoGSL) {
+        print "Auto-detecting GSL location\n";
+        my $gpre = `gsl-config --prefix`;
+        chomp($gpre);
+        $libs{'gsl'}=$gpre;
+    } else {
+        $libs{'gsl'}=$ENV{GSLDIR} unless exists $libs{'gsl'};
+    }
     &set_libs;
 }
 
@@ -98,17 +136,30 @@ sub set_libs
     }else{
 	open(FILE, '>', '../../LibLocations.txt');
     }
-    if($SchemeUser eq 'True'){
+    if ($SchemeUser eq 'True') {
         $lib_cmd=$lib_cmd . "\\\n\t-L$libs{'netcdf'}/lib -lnetcdff";
         $lib_cmd=$lib_cmd . "\\\n\t-L$libs{'gsl'}/lib -lgsl -lgslcblas -lm";
-    }else{
-        foreach(keys(%libs)){
-	    if($libs{$_}){
-	        $lib_cmd=$lib_cmd . "\\\n\t-L$libs{$_}/lib -l$_ ";
-    	        $lib_cmd=$lib_cmd . '-lnetcdff ' if($_ eq 'netcdf');
-                $lib_cmd=$lib_cmd . '-lgslcblas -lm ' if($_ eq 'gsl');
+    } else {
+        foreach (keys(%libs)) {
+	        if($libs{$_}){
+                if (($_ eq 'netcdf') and $DoAutoNCF) {
+                    my $nclibs = `nf-config --flibs`;
+                    chomp($nclibs);
+    	            $lib_cmd = $lib_cmd . $nclibs . " ";
+                } elsif ($_ eq 'netcdf') {
+                    $lib_cmd=$lib_cmd . "\\\n\t-L$libs{$_}/lib -l$_ ";
+    	            $lib_cmd=$lib_cmd . '-lnetcdff ';
+                }
+                if (($_ eq 'gsl') and $DoAutoGSL) {
+                    my $gsllibs = `gsl-config --libs`;
+                    chomp($gsllibs);
+                    $lib_cmd = $lib_cmd . $gsllibs. " ";
+                } elsif ($_ eq 'gsl') {
+                    $lib_cmd=$lib_cmd . "\\\n\t-L$libs{$_}/lib -l$_ ";
+                    $lib_cmd=$lib_cmd . '-lgslcblas -lm ';
+                }
     	        print FILE "$_  $libs{$_}\n";
-    	    }else{
+    	    } else {
     	        $lib_cmd=$lib_cmd . "\\\n\t-l$_ ";
                 $lib_cmd=$lib_cmd . '-lnetcdff ' if($_ eq 'netcdf');
     	        print FILE "$_  (default lib path)\n";
@@ -124,7 +175,7 @@ sub set_libs
     $MakefileConfEdit = '../../Makefile.conf' if($IsStandalone eq 'False');
     $MakefileDefEdit  = '../../Makefile.def'  if($IsStandalone eq 'False');
 
-    print "Editing $MakefileConfEdit\n";
+    print "\nEditing $MakefileConfEdit\n";
 
     # Open Makefile.conf, insert libflags before Lflag1.
     @ARGV = ($MakefileConfEdit);
@@ -141,25 +192,41 @@ sub set_libs
     my $modpath = '';
     `echo  >> $MakefileDefEdit`;   # Add some spaces
     `echo  >> $MakefileDefEdit`;   # to end of file...
-    if($SchemeUser eq 'True') {
+    if ($SchemeUser eq 'True') {
         $modpath = "$libs{'netcdf'}/include";
        `echo NETCDF_PATH = $modpath >> $MakefileDefEdit`;
         $modpath = "$libs{'gsl'}/include";
        `echo GSL_PATH = $modpath >> $MakefileDefEdit`;
-    }else{
-        foreach(keys(%libs)){
-	    if(/netcdf/){
-	        $modpath = $libs{$_} ? "$libs{$_}/include" : "/usr/lib/netcdf/include";
-           `    echo NETCDF_PATH = $modpath >> $MakefileDefEdit`;
-	    }
+    } else {
+        foreach (keys(%libs)) {
+	        if (/netcdf/) {
+                if ($DoAutoNCF) {
+	                $modpath = `nf-config --includedir`;
+                    chomp($modpath);
+                } else {
+	                $modpath = $libs{$_} ? "$libs{$_}/include" : `nc-config --includedir`;
+                }
+                `echo NETCDF_PATH = $modpath >> $MakefileDefEdit`;
+	        }
             if(/gsl/){
-                $modpath = $libs{$_} ? "$libs{$_}/include" : "/usr/lib/gsl/include";
-           `    echo GSL_PATH = $modpath >> $MakefileDefEdit`;
+                if ($DoAutoGSL) {
+                    my $gsl_include = `gsl-config --prefix`;
+                    chomp($gsl_include);
+                    $modpath = ${gsl_include}."/include";
+                } else {
+                    $modpath = $libs{$_} ? "$libs{$_}/include" : "/usr/lib/gsl/include";
+                }
+                `echo GSL_PATH = $modpath >> $MakefileDefEdit`;
             }
         }
     }
-
 }
+
+sub check_exists { 
+    my $check = `sh -c 'command -v $_[0]'`; 
+    return $check;
+}
+
 #=============================================================================
 sub print_help
     # Print RAM-SCB help.

--- a/Config.pl
+++ b/Config.pl
@@ -240,7 +240,9 @@ Additional options for RAM-SCB/Config.pl:
 These MUST be set if environment variables GSLDIR and
 NETCDFDIR are not set.  If both flag and env variable are
 set, Config.pl will use the flag value.  This allows for
-multiple installations of the libraries.
+multiple installations of the libraries. If the flags are set
+no path is given (e.g., '-ncdf') then Config.pl will use the
+libraries own utility to look up required information.
     
 Example installation for RAM-SCB standalone:
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 The **R**ing current **A**tmosphere interactions **M**odel with **S**elf **C**onsistent magnetic field (**B**) is a unique code that combines a kinetic model of ring current plasma with a three dimensional force-balanced model of the terrestrial magnetic field. The kinetic portion, RAM, solves the kinetic equation to yield the bounce-averaged distribution function as a function of azimuth, radial distance, energy and pitch angle for three ion species (H+, He+, and O+) and, optionally, electrons. The 3-D force balanced magnetic field model, SCB, balances the **J** × **B** force with the divergence of the general pressure tensor to calculate the magnetic field configuration within its domain. The two codes work in tandem, with RAM providing anisotropic pressure to SCB and SCB returning the self-consistent magnetic field through which RAM plasma is advected. RAM-SCB has grown from a research-grade code with limited options and static magnetic field (RAM) to a rich, highly configurable research and operations tool with a multitude of new physics and output products. The RAM-SCB manual provides a guide to users who want to learn how to install, configure, and execute RAM-SCB simulations. While the code is designed to make these steps as straight-forward as possible, it is strongly recommended that users review the publications listed in the Bibliography to ensure a thorough understanding of the physics included in the model.
 
+
 ## Documentation
 
 The RAM-SCB manual with extended installation and usage information can be found at [RAM-SCB/doc/RAM_SCB.pdf](doc/RAM_SCB.pdf).
+
 
 ## Attribution
 
@@ -20,12 +22,25 @@ Researchers who use the RAM-SCB code for scientific research are asked to cite t
 
 4. Welling, D. T., V. K. Jordanova, S. G. Zaharia, A. Glocer, and G. Toth (2011), The effects of dynamic ionospheric outflow on the ring current, J. Geophys. Res., 116, doi:10.1029/2010JA015642.
 
+
 ## Installation
 
-```
-Config.pl -install -compiler=pgf90 -mpi=mpich2
-make
-````
+For full installation details, please see the documentation folder.
+
+To install on Linux (or similar), three main steps are required:
+1. Install preqreuisites
+  - Fortran/C/C++ compilers are required, we recommend `gfortran`/`gcc`/`g++`
+  - GSL is required
+  - NetCDF-Fortran is required
+  - Perl is required (standard on most linux systems)
+2. Configure the build
+  - Setup is done using the `Config.pl` Perl script. This sets up the make system and tells RAM-SCB where to find its dependencies.
+  - An example setup: `./Config.pl -install -compiler=gfortran -mpi=openmpi -openmp -ncdf -gsl`
+  - If `Config.pl` shows the warning "Can't locate share/Scripts/Config.pl in @INC" then add the RAM-SCB directory to the Perl path. In `bash` this is done with ``export PER5LIB=`pwd` ``
+  - Most installations of NetCDF4 and GSL should come with command line utilities to help determine library locations and flags. To auto-detect these use the `-ncdf` and `-gsl` flags without specifying a library location.
+3. Compile the code
+  - Simply run `make`. If you have multiple cores available for compilation then you can speed things up by running `make -j`
+
 
 ## Usage
 
@@ -38,11 +53,12 @@ make rundir RUNDIR=~/desired_run_directory
 
 This software has been approved for open source release and has been assigned LA-CC-16-077.
 
+
 ## License
 
 The RAM-SCB License can be found at [RAM-SCB/LICENSE.txt](LICENSE.txt).
 
+
 ## Contact
 
 For questions about using RAM-SCB please contact [Vania Jordanova](http://www.lanl.gov/expertise/profiles/view/vania-jordanova).
-

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To install on Linux (or similar), three main steps are required:
 2. Configure the build
   - Setup is done using the `Config.pl` Perl script. This sets up the make system and tells RAM-SCB where to find its dependencies.
   - An example setup: `./Config.pl -install -compiler=gfortran -mpi=openmpi -openmp -ncdf -gsl`
-  - If `Config.pl` shows the warning "Can't locate share/Scripts/Config.pl in @INC" then add the RAM-SCB directory to the Perl path. In `bash` this is done with ``export PER5LIB=`pwd` ``
+  - If `Config.pl` shows the warning "Can't locate share/Scripts/Config.pl in @INC" then add the RAM-SCB directory to the Perl path. In `bash` this is done with ``export PERL5LIB=`pwd` ``
   - Most installations of NetCDF4 and GSL should come with command line utilities to help determine library locations and flags. To auto-detect these use the `-ncdf` and `-gsl` flags without specifying a library location.
 3. Compile the code
   - Simply run `make`. If you have multiple cores available for compilation then you can speed things up by running `make -j`


### PR DESCRIPTION
The current `Config.pl` allows for specification of the locations of both NetCDF4 and GSL, but assumes a directory structure that isn't necessarily respected on system installs. It also requires the user to explicitly know where these libraries are located and appropriate flags are hard-coded.

This PR updates this by adding the option to use `nf-config` and `gsl-config` to look up the install locations and flags.
The installation instructions in the README are also expanded.

Old behaviour is preserved.
New behaviour is that supplying `-ncdf` and `-gsl` flags without a corresponding value will then attempt to use the config utilities to look up the location and flags for each dependent library.

(Edit to note that the force-push was after rebasing against master to ensure that the PR can be rebase-merged)