### PR TITLE
Fixes for GCC10

### DIFF
--- a/Config.pl
+++ b/Config.pl
@@ -68,6 +68,8 @@ foreach(@Arguments){
                 # If compiler name starts with gfortran.
                 if (gfort_ge_10()) {
                     $extra_flags = $extra_flags . " -fallow-argument-mismatch";
+                    # Remove following line when share library is updated to remove octal mask setting
+                    $extra_flags = $extra_flags . " -fallow-invalid-boz";
                 }
             }
         }

--- a/Config.pl
+++ b/Config.pl
@@ -249,10 +249,8 @@ sub check_exists {
 
 sub gfort_ge_10 {
     # Test gfortran version. Return 1 if version GE 10
-    my $verout = `gfortran --version | head -1`;
-    my @parts = split / /, $verout;
-    my $version = @parts[$#parts];
-    return CPAN::Version->vge("$version","10") ? 1 : 0;
+    my $verout = `$compiler -dumpversion`;
+    return CPAN::Version->vge("$verout","10") ? 1 : 0;
 }
 
 #=============================================================================


### PR DESCRIPTION

This pull request adds a version check if the supplied compiler begins with `gfortran` (compatible with `gfortran` and `gfortran-10`, as name can depend on system setup).

If the compiler name starts with `gfortran` and the version number is greater-than-or-equal-to 10, the `-fallow-argument-mismatch` and `-fallow-invalid-boz` flags get added to `Makefile.conf`.

The addition of the first flag resolves #79 and the addition of the second flag provides a temporary workaround for #78  