### PR TITLE
Config.pl: add GSL include dir to C compilation

### DIFF
--- a/schemeSetup.sh
+++ b/schemeSetup.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-module2 load gsl/2.3
-module2 load openmpi
-module2 load gcc/8.1.0
-export LD_LIBRARY_PATH=/projects/lanl/Carrington/netcdf/lib:${LD_LIBRARY_PATH}
-./Config.pl -install -scheme
+module load perl/5.24.1
+module load gcc/9.3.0
+module load gsl/2.6
+module load openmpi/4.0.5
+module load netcdf
+
+perl Config.pl -install -ncdf -gsl -compiler=gfortran -openmp -mpi=openmpi


### PR DESCRIPTION
Compilation failed on CCMC's AWS server due to the GSL include directory not being explicitly specified for the compilation of `src\RamGSL.c`.

This PR makes `Config.pl` populate the `FLAGC_EXTRA` variable in `Makefile.conf`, so that the GSL include directory is passed as as `-I` argument to the `gcc` calls.


Can I ask @Pheosics and @kyakymenko to make sure that everything still installs fine on their systems with this PR? This works for me on Ubuntu 20.04 (on WSL2), as well as CentOS 7 (the AWS instance), and I just want to make sure it's as robust as I think it is.