### PR TITLE
Correct build of GitHub Actions test runner

### DIFF
--- a/.github/workflows/ramscb-ci.yml
+++ b/.github/workflows/ramscb-ci.yml
@@ -21,10 +21,6 @@ jobs:
         sudo apt-get install -y make libopenmpi-dev openmpi-bin
         sudo apt-get install -y libgsl-dev libgsl2 gsl-bin libgsl-dbg
         sudo apt-get install -y libnetcdf-dev libnetcdff-dev nco netcdf-bin
-        sudo apt-get install -y python3-pip python3-setuptools python3-wheel
-        pip3 install numpy scipy matplotlib
-        pip3 install spacepy
-        pip3 freeze
         gfortran --version
         gsl-config --version
     - name: Checkout


### PR DESCRIPTION
Initial commit of the GH actions test runner fails because we're on Ubuntu 16.04 (for compatibility with the old Docker container). That means the version of Python 3 installed is too old and subsequent installation of `numpy` errors and kills the build.

This PR amends the test runner so that the setup, etc. all works and the `testTravis` test is run (same as the old TravisCI runner). Runtime on first action was 8m30s. Any additional tests should probably be run with parallel actions.

This covers part of #81, in that the CI will now be active again. However, the `gcc`/`gfortran` version is ancient and it's using Ubuntu 16.04 which will be dropped by GitHub Actions in September. So those updates (which will require updating test results) still need to be made and are fairly high priority.