### PR TITLE
Add unit testing capability to RAM-SCB

### DIFF
--- a/.github/workflows/ramscb-ci.yml
+++ b/.github/workflows/ramscb-ci.yml
@@ -31,3 +31,6 @@ jobs:
         ./Config.pl -install -compiler=gfortran -mpi=openmpi -openmp -ncdf -gsl -O3
         make
         make testTravis
+    - name: unit_tests
+      run: |
+        make unittest

--- a/Makefile
+++ b/Makefile
@@ -103,11 +103,26 @@ rundir:
 #---------
 # TESTS
 #---------
+
+unittest:
+	@cd ${SHAREDIR}; make LIB
+	@cd srcExternal; make LIB
+	@cd ${srcDir};   make LIB
+	@cd ${srcDir};   make tests
+	@(make unittest_run)
+
 TESTDIR1 = run_test1
 TESTDIR2 = run_test2
 TESTDIR3 = run_test3
 TESTDIR4 = run_test4
 TESTDIRC = run_test
+TESTDIRU = run_unittest
+
+unittest_run:
+	@rm -rf ${TESTDIRU}
+	@make rundir RUNDIR=${TESTDIRU} STANDALONE="YES"
+	@mv ${srcDir}/unittest.exe ${TESTDIRU}
+	@cd ${TESTDIRU}; ./unittest.exe
 
 test:
 	@(make test1)

--- a/src/CONTRIBUTING.md
+++ b/src/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contributing to RAM-SCBE
+
+Bug reports, suggested enhancements, and other contributions
+are always appreciated! RAM-SCBE is free, open-source software
+for the space physics community and welcomes both use and
+engagement.
+
+## Bug Reports and contributions
+
+### Filing issues
+
+When filing an issue, please include:
+- Your operating system name/version
+- Which compilers and dependent packages you're using
+- Detailed steps, preferably on a minimal example, to reproduce your issue
+- Log files and/or full error messages
+
+### Contributing code
+
+Contributions to RAM-SCBE are managed through pull requests
+on [our GitHub repository](https://github.com/lanl/RAM-SCB).
+Further details on the workflow are given in <WORKFLOW.md>.
+
+If you have any questions about how to write the code, either
+comment on the open issue that your code addresses or submit a
+draft pull request and ask for help.
+
+## Coding style and standards
+
+RAM-SCBE has developed and evolved over a long time period.
+The code has been modernized during updates, but at this time
+different coding styles and standards are seen across the code.
+As further developments are made, we are encouraging the Fortran
+2008 standard.
+
+- RAM-SCBE uses free-format Fortran code
+- When using a module, please use `use ModNameHere, ONLY: var, sub` to list the members being used
+- Functions are preferred where code is not dependent on state parameters
+  - "New-style" functions should be used, such that the result variable is declared on the same line as the function and there is no `return` statement at the end of the function.
+- Subroutines should minimize the number of used state parameters
+- RAM-SCBE uses a two-space indent, and spaces should be used in-code for readability
+- Please provide copious comments. They should be descptive (what is this doing?) as well as explanatory (why is it doing this?)
+- When contributing new code, please extend the test suite (see next section)
+- When contributing code, please update the documentation as appropriate.
+- *Do not* use Fortran 77 features, including:
+  - Common blocks
+  - GOTO statements
+  - Implicit variable typing
+  - Statement labels (i.e., numbered statements for flow control)
+
+## Testing in RAM-SCBE
+
+RAM-SCB has two primary approaches to testing. The first is integration
+testing, where a short model run is defined and the output is compared
+to a known result. This serves partly as a regression test, and partly
+to ensure that the simulation runs end-to-end and gives a sensible result.
+These tests are run via the Makefile by, e.g., `make test1`
+
+The second approach to testing is unit testing. Rather than define a run and
+use the computational resources required for even short simulations, unit
+testing concentrates on small pieces of code and checks them, in isolation,
+for correctness. This complements the integration approach, and the unit test
+suite can be run via the Makefile with `make unittest`
+
+### Adding a new unit test
+
+Ideally, new code will have unit test coverage. Depending on your preferred style,
+the unit tests can be written first (so the code will have a pre-defined calling
+syntax when you go to write it), or after the fact. Adding tests to the unit test
+suite involves two steps:
+1. Write the test subroutine at the end of the module where the code being tested is.
+2. Add a line calling the test subroutine in `src/test_suite.f90`
+
+The test subroutine should update the module variables `nTestPassed` and `nTestRun`,
+from `ModRamMain`. A sample stub for a test is given below:
+```
+subroutine test_npifunction(verbose)
+  ! Comments describing your test(s) go here
+  ! 1. Test that npifunction returns a correct approximation to n*pi
+  use ModRamMain,    ONLY: Real8_, test_neq_abs, nTestPassed, nTestRun
+
+  implicit none
+  logical, intent(in) :: verbose
+  logical :: failure, all_pass
+  integer :: idx
+  real(Real8_), dimension(3) :: expect = (/3.14, 6.28, 9.42/)
+  real(Real8_), dimension(3) :: answer
+
+  ! Call the new code and test that everything passes
+  all_pass = .TRUE.  ! Start as true and flip to false if anything fails
+  do idx=1,3
+    answer(idx) = npifunction(real(idx))
+    call test_neq_abs(answer(idx), expect(idx), failure)
+    ! The failure variable will be .TRUE. if answer and expect are not equal
+    if (failure) all_pass = .FALSE.
+  end do
+  ! set verbose output, so we can inspect what failed if required
+  if (verbose) then
+    write(*,"(A25,3F12.8))") "test_npifunction: got = ", answer
+    write(*,"(A25,3F12.8))") "             expected = ", expect
+  end if
+  ! and now update the test counters
+  nTestRun = nTestRun + 1
+  if (all_pass) then
+    nTestPassed = nTestPassed + 1
+  end if
+  ! if required, additional tests for the same function can be
+  ! put here, just make sure the counters are updated after every test
+end subroutine test_npifunction
+```
+
+### Adding a new integration test
+Major new functionality should have a short integration test that exercises it.
+Configurations for the integration tests are given in <Param> and are named for
+the test. E.g., <Param/PARAM.in.test1> or <Param/PARAM.in.testEMIC>. Expected
+test results are stored in the appropriately named folder in <output>, e.g.,
+<output/test1> or <output/testEMIC> for the examples given previously.

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,6 +9,7 @@ include Makefile.RULES
 
 # Name the executable and library target.
 EXE = ${BINDIR}/ram_scb.exe
+TEST = ${BINDIR}/unittest.exe
 MY_LIB = libRAM_SCB.a
 
 # Other required libraries.
@@ -92,6 +93,7 @@ OBJECTS = ${RAM_OBJECTS} ${SCB_OBJECTS} ${SCE_OBJECTS} ${EXT_OBJECTS} ${GSL_OBJE
 
 # List of objects required for executable:
 OBJECTS_EXE = Main.o
+TEST_EXE = test_suite.o
 
 DEPEND:
 	${SCRIPTDIR}/depend.pl ${SEARCH} ${OBJECTS}
@@ -125,12 +127,25 @@ RAM_SCB: DEPEND
 	@echo "Program ${EXE} has been brought up to date."
 	@echo ' '
 
+tests: DEPEND
+	@make ${TEST}
+
+combine:
+	echo 'create libAll.a\n' > mergelibs.mri
+	echo 'addlib ${MY_LIB}\n' >> mergelibs.mri
+	echo 'addlib ${LIBSHARE}\n' >> mergelibs.mri
+	echo 'addlib ${LIBEXT}\n' >> mergelibs.mri
+	echo 'save\n' >> mergelibs.mri
+	echo 'end\n' >> mergelibs.mri
+	ar -M < mergelibs.mri
+
 # Libraries should be compiled first, because modules are used in main
 ${EXE}: ${OBJECTS_EXE} ${MY_LIB} ${LIBSHARE} ${LIBEXT}
-	rm -rf Tmp_; mkdir Tmp_
-	cd Tmp_; \
-		ar -x ../${MY_LIB}; \
-		ar -x ${LIBSHARE}; \
-		ar -x ${LIBEXT};
-	${LINK.f90} -o ${EXE} ${OBJECTS_EXE} Tmp_/*.o ${LBLAS} ${Lflag1}
-	rm -rf Tmp_
+	make combine
+	rm mergelibs.mri
+	${LINK.f90} -o ${EXE} ${OBJECTS_EXE} libAll.a ${LBLAS} ${Lflag1}
+
+${TEST}: ${TEST_EXE} ${MYLIB} ${LIBSHARE} ${LIBEXT}
+	make combine
+	rm mergelibs.mri
+	${LINK.f90} -I${INCLDIR} -o ${TEST} ${TEST_EXE} libAll.a ${LBLAS} ${Lflag1}

--- a/src/ModRamFunctions.f90
+++ b/src/ModRamFunctions.f90
@@ -666,7 +666,7 @@ module ModRamFunctions
     all_pass = .TRUE.
     do ii=0,2
       answer(ii+1) = erff(-1.d0*REAL(ii)/2.d0)
-      call test_neq_abs(answer(ii+1), -1.d0*expect(ii+1), 0.0001, failure)
+      call test_neq_abs(answer(ii+1), -1.d0*expect(ii+1), 1.0d-8, failure)
       if (failure) all_pass = .FALSE.
     end do
     if (verbose) then
@@ -682,7 +682,8 @@ module ModRamFunctions
 
   subroutine test_Gcoul(verbose)
     ! Tests:
-    ! 1. ERFF and dependent functions
+    ! 1. G function for coulomb collisions with zero input
+    ! 2. As above for valid input
     use, intrinsic :: IEEE_arithmetic
     use ModRamMain,      ONLY: Real8_, test_neq_abs, nTestPassed, nTestRun
 
@@ -708,7 +709,7 @@ module ModRamFunctions
     do ii=1,3
       ! Gcoul of [0.5, 1, 1.5]
       answer(ii) = Gcoul(REAL(ii)/2.d0)
-      call test_neq_abs(answer(ii), expect(ii), 0.0001, failure)
+      call test_neq_abs(answer(ii), expect(ii), 1.0d-8, failure)
       if (failure) all_pass = .FALSE.
     end do
     if (verbose) then

--- a/src/ModRamIndices.f90
+++ b/src/ModRamIndices.f90
@@ -292,7 +292,6 @@ module ModRamIndices
 
     implicit none
     logical, intent(in) :: verbose
-    real(Real8_) :: test_err
     logical :: failure
     type(TimeType) :: StartTime, EndTime, TestTime
 

--- a/src/ModRamIndices.f90
+++ b/src/ModRamIndices.f90
@@ -21,6 +21,7 @@ module ModRamIndices
     use ModRamParams,   ONLY: DoUseEMIC
     use ModTimeConvert, ONLY: TimeType, time_int_to_real
     use ModIoUnit,      ONLY: UNITTMP_
+    use ModUtilities,   ONLY: CON_stop, CON_set_do_test 
 
 
     implicit none
@@ -172,6 +173,7 @@ module ModRamIndices
     use ModRamVariables, ONLY: NameIndexSource
 
     use ModTimeConvert, ONLY: TimeType
+    use ModUtilities,   ONLY: CON_stop, CON_set_do_test 
 
     implicit none
 

--- a/src/ModRamIndices.f90
+++ b/src/ModRamIndices.f90
@@ -280,4 +280,49 @@ module ModRamIndices
     endif
   end subroutine update_indices
   !===========================================================================
+
+  subroutine test_update_indices(verbose)
+    ! Tests:
+    ! 1. Load of RamIndices.txt
+    ! 2. Interpolation of Kp to specific times by update_indices
+    use ModRamMain,      ONLY: make_time, Real8_, test_neq_abs, nTestPassed, nTestRun
+    use ModTimeConvert,  ONLY: TimeType
+    use ModRamVariables, ONLY: Kp, NameIndexSource
+    use ModRamParams,    ONLY: DoUseEMIC, FixedComposition
+
+    implicit none
+    logical, intent(in) :: verbose
+    real(Real8_) :: test_err
+    logical :: failure
+    type(TimeType) :: StartTime, EndTime, TestTime
+
+    call make_time(2013, 3, 16, 0, 0, 0, 0.0, StartTime)
+    call make_time(2013, 3, 17, 0, 0, 0, 0.0, TestTime)
+    call make_time(2013, 3, 17, 5, 0, 0, 0.0, EndTime)
+
+    NameIndexSource = 'file'
+    DoUseEMIC = .FALSE.
+    FixedComposition = .TRUE.
+    ! Implicit test of index file intialization
+    call init_indices(StartTime, EndTime)
+    ! Explicit test of index interpolation
+    call update_indices(TestTime%Time)
+    call test_neq_abs(Kp, 1.65, 0.001, failure)
+    nTestRun = nTestRun + 1
+    if (.not.failure) then
+      if (verbose) write(*,*) "test_update_indices(1): Kp = ", Kp, " (expected 1.65)"
+      nTestPassed = nTestPassed + 1
+    end if
+    ! Explicit test of index interpolation (#2)
+    call make_time(2013, 3, 17, 4, 30, 0, 0.0, TestTime)
+    call update_indices(TestTime%Time)
+    call test_neq_abs(Kp, 2.3, 0.001, failure)
+    nTestRun = nTestRun + 1
+    if (.not.failure) then
+      if (verbose) write(*,*) "test_update_indices(2): Kp = ", Kp, " (expected 2.3)"
+      nTestPassed = nTestPassed + 1
+    end if
+
+  end subroutine test_update_indices
+  !===========================================================================
 end module ModRamIndices

--- a/src/ModRamMain.f90
+++ b/src/ModRamMain.f90
@@ -5,7 +5,7 @@
 
 module ModRamMain
 
-  use ModTimeConvert, ONLY: TimeType
+  use ModTimeConvert, ONLY: TimeType, time_int_to_real
   use nrtype,         ONLY: DP, SP
   use ModRamGrids,    ONLY: NS, NR, NT, NE, NPA
 
@@ -38,7 +38,33 @@ module ModRamMain
   integer :: nIter ! Tracks iteration, including restart.
 !!!!!
 
+!!!!! TESTING
+  integer :: nTestPassed
+  integer :: nTestRun
 !  integer :: S
+
+  contains
+
+  subroutine make_time(yr, mon, day, hr, min, sec, frs, timeObj)
+    integer, intent(in) :: yr, mon, day, hr, min, sec
+    real(Real8_), intent(in) :: frs
+    type(TimeType), intent(inout) :: timeObj
+
+    timeObj%iYear = yr
+    timeObj%iMonth = mon
+    timeObj%iDay = day
+    timeObj%iHour = hr
+    timeObj%iMinute = min
+    timeObj%iSecond = sec
+    timeObj%FracSecond = frs
+    call time_int_to_real(timeObj)
+  end subroutine make_time
+
+  subroutine test_neq_abs(val1, val2, atol, result)
+    real(Real8_), intent(in) :: val1, val2, atol
+    logical, intent(inout) :: result
+    result = merge(.TRUE., .FALSE., abs(val1 - val2).gt.atol)
+  end subroutine test_neq_abs
 
 end Module ModRamMain
 !==============================================================================

--- a/src/test_suite.f90
+++ b/src/test_suite.f90
@@ -1,6 +1,7 @@
-program run_test_update_indices
-    use ModRamMain,    ONLY: nTestPassed, nTestRun
-    use ModRamIndices, ONLY: test_update_indices
+program run_test_suite
+    use ModRamMain,      ONLY: nTestPassed, nTestRun
+    use ModRamIndices,   ONLY: test_update_indices
+    use ModRamFunctions, ONLY: test_erf, test_Gcoul
     
     implicit none
     character(25) :: arg1
@@ -19,6 +20,8 @@ program run_test_update_indices
 
     ! Tests go here...
     call test_update_indices(verbose)
+    call test_erf(verbose)
+    call test_Gcoul(verbose)
 
     ! And after all the tests print the test status
     write(*,*) nTestPassed, "out of ", nTestRun, " tests passed"
@@ -27,4 +30,4 @@ program run_test_update_indices
       STOP -1
     end if
   
-end program run_test_update_indices
+end program run_test_suite

--- a/src/test_suite.f90
+++ b/src/test_suite.f90
@@ -1,0 +1,30 @@
+program run_test_update_indices
+    use ModRamMain,    ONLY: nTestPassed, nTestRun
+    use ModRamIndices, ONLY: test_update_indices
+    
+    implicit none
+    character(25) :: arg1
+    logical :: verbose
+  
+    !First, make sure the right number of inputs have been provided
+    if (command_argument_count().gt.1)THEN
+      write(*,*) 'Error: Only one argument is currently supported'
+      STOP
+    end if
+    
+    ! check for -v, -verbose, etc. as command line argument
+    verbose = .FALSE.
+    call get_command_argument(1, arg1)   ! read variable
+    if ((index(arg1, '-v') == 1) .or. (index(arg1, '-V') == 1)) verbose = .TRUE.
+
+    ! Tests go here...
+    call test_update_indices(verbose)
+
+    ! And after all the tests print the test status
+    write(*,*) nTestPassed, "out of ", nTestRun, " tests passed"
+
+    if (nTestPassed .NE. nTestRun) then
+      STOP -1
+    end if
+  
+end program run_test_update_indices

--- a/src/test_suite.f90
+++ b/src/test_suite.f90
@@ -14,7 +14,7 @@ program run_test_suite
     end if
     
     ! check for -v, -verbose, etc. as command line argument
-    verbose = .FALSE.
+    verbose = .FALSE.  ! default is not verbose
     call get_command_argument(1, arg1)   ! read variable
     if ((index(arg1, '-v') == 1) .or. (index(arg1, '-V') == 1)) verbose = .TRUE.
 
@@ -27,7 +27,7 @@ program run_test_suite
     write(*,*) nTestPassed, "out of ", nTestRun, " tests passed"
 
     if (nTestPassed .NE. nTestRun) then
-      STOP -1
+      STOP -1  ! if any tests fail, return a negative code so CI will report an error
     end if
   
 end program run_test_suite


### PR DESCRIPTION
The PR makes a number of changes to enable more fine-grained testing within RAM-SCB. Currently testing is done with a few end-to-end tests that then compare output to the previous result. The aim here is to enable specific testing *for correctness* against expected results, using shorter sections of code; i.e., this enables testing without running RAM-SCB as a simulation code.

Specific updates:
- Added some missing `use` statements that prevented compilation of external source using libRAMSCB
- Unit test program added and included in `Makefile` (build/run with `make unittest`)
- Combine static libraries for compilation, rather than unpacking to temp directory
- Short test added for `init_indices`/`update_indices` in `ModRamIndices`
- Short tests added for `erff` and `Gcoul` in `ModRamFunctions`
- Hook unit testing into GitHub Actions continuous integration
- `CONTRIBUTING.md` added with info about contributing code, filing issues, adding tests, code style, etc.