### PR TITLE
Fix string comparison in viz scripts

### DIFF
--- a/Scripts/viz/convertRAMrestart.py
+++ b/Scripts/viz/convertRAMrestart.py
@@ -140,7 +140,7 @@ def gen_vtx(fileName, pressure=True, field=True, verbose=False):
         for partname in ['Lines', 'Strips', 'Polys']:
             dac = lxml.etree.Element('DataArray', type='Int64', Name='connectivity', RangeMax='{}'.format(npts), RangeMin='0')
             dao = lxml.etree.Element('DataArray', type='Int64', Name='offsets', RangeMin='{}'.format(0), RangeMax='{}'.format(npts))
-            if partname is 'Polys':
+            if partname == 'Polys':
                 #write the polygons that connect the points together, defining the grid
                 polyconn = getPolyVertOrder(npts, nT, nR)
                 nconn = len(polyconn)

--- a/Scripts/viz/makeCustomSource.py
+++ b/Scripts/viz/makeCustomSource.py
@@ -115,7 +115,7 @@ def xmlPolyGen(xyz, dim1, dim2):
     for partname in ['Lines', 'Strips', 'Polys']:
         dac = lxml.etree.Element('DataArray', type='Int64', Name='connectivity', RangeMax='{}'.format(npts), RangeMin='0')
         dao = lxml.etree.Element('DataArray', type='Int64', Name='offsets', RangeMin='{}'.format(0), RangeMax='{}'.format(npts))
-        if partname is 'Polys':
+        if partname == 'Polys':
             #write the polygons that connect the points together, defining the grid
             polyconn = getPolyVertOrder(len(xyz), dim1, dim2)
             nconn = len(polyconn)


### PR DESCRIPTION
The visualization scripts for converting RAM-SCB restarts to VTK and for generating VTK sources for plotting use outdated idiom that's no longer supported in recent Python versions.
This changes the string equality comparison so the codes now run under modern Python.