### PR TITLE
Reduce docker image size by including .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+.github
+Dockerfile*
+docker-compose*

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@
 .github
 Dockerfile*
 docker-compose*
+*/__pycache__
+*/*/__pycache__
+*/*/images
+*/*/vtk_files


### PR DESCRIPTION
Makes sure that git history and some other target locations that may be generated in local checkouts of the repo aren't included in the context when copying the project to the Docker image.