### PR TITLE
Updates for runs-on-request job launch and flux boundary handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,17 @@
 .git
 .gitignore
 .github
+*/.git
+*/.gitignore
+*/.github
 Dockerfile*
+*/Dockerfile*
 docker-compose*
+*/docker-compose*
 */__pycache__
 */*/__pycache__
+*/*/*/__pycache__
 */*/images
+*/*/*/images
 */*/vtk_files
+*/*/*/vtk_files

--- a/Dockerfile.RoR
+++ b/Dockerfile.RoR
@@ -3,6 +3,8 @@
 # parent directory. Then copy .dockerignore into the parent.
 # To build:
 # docker build -t git.smce.nasa.gov:5050/ccmc-ram-scb/ram-scb -f RAM-SCB/Dockerfile.RoR .
+# To run locally (from a directory containing a suitable PARAM.in file):
+# docker run -v $(pwd):/input [image ID] -d /runror /input/PARAM.in
 FROM ubuntu:20.04
 ENV PERL5LIB=.
 ENV DEBIAN_FRONTEND=noninteractive 

--- a/Dockerfile.RoR
+++ b/Dockerfile.RoR
@@ -1,10 +1,20 @@
+# To build for RoR, first check out the flux-model repository
+# so that the RAM-SCB and flux-model repos have a common
+# parent directory. Then copy .dockerignore into the parent.
+# To build:
+# docker build -t git.smce.nasa.gov:5050/ccmc-ram-scb/ram-scb -f RAM-SCB/Dockerfile.RoR .
 FROM ubuntu:20.04
 ENV PERL5LIB=.
 ENV DEBIAN_FRONTEND=noninteractive 
 
-RUN apt-get update && apt-get install -y ssh make gcc git g++ gfortran libopenmpi-dev openmpi-bin libgsl-dev libgsl23 gsl-bin libgsl-dbg libnetcdf-dev libnetcdff-dev nco netcdf-bin python3 python-is-python3
+RUN apt-get update && apt-get install -y ssh make gcc git g++ gfortran libopenmpi-dev openmpi-bin libgsl-dev libgsl23 gsl-bin libgsl-dbg libnetcdf-dev libnetcdff-dev nco netcdf-bin python3 python3-pip python-is-python3
 
-COPY . /SHIELDS
+RUN pip install numpy==1.18 && pip install spacepy==0.4.1
+
+COPY flux-model /SHIELDS/flux-model
+WORKDIR /SHIELDS/flux-model
+RUN pip install .
+COPY RAM-SCB /SHIELDS
 WORKDIR /SHIELDS
 RUN ./Config.pl -install -compiler=gfortran -mpi=openmpi -openmp -gsl -ncdf && make
 

--- a/Param/PARAM.in.RoR
+++ b/Param/PARAM.in.RoR
@@ -1,0 +1,163 @@
+Example PARAM file with all options listed (the listed options are the program defaults)
+
+#DESCRIPTION
+A description of your run can go here
+
+#EVENT
+The name of your event can go here
+
+************** REQUIRED BLOCK ***************** ! These are the only required pieces that must be included in every RAM-SCB run (if restarting a run, replace STARTTIME with RESTART)
+#STARTTIME
+ReplStartYYYY		iYear			! Sets the year, month, day, hour, and minute for run start
+ReplStartMM		iMonth
+ReplStartDD		iDay
+ReplStarthh		iHour
+ReplStartmm		iMinute
+0                       iSecond
+0.0                     FracSecond
+
+#STOPTIME
+ReplEndYYYY		iYear                   ! Sets the year, month, day, hour, and minute for run stop
+ReplEndMM		iMonth
+ReplEndDD		iDay
+ReplEndhh		iHour
+ReplEndmm		iMinute
+0                       iSecond
+0.0                     FracSecond
+
+***********************************************
+
+*************** TIMING BLOCK ******************
+#MAXTIMESTEP
+100.0			MaxHalfStep		! The maximum half time step (in seconds) that RAM will take, regardless of other factors
+
+#MINTIMESTEP
+0.2			MinHalfStep		! The minimum half time step (in seconds) that RAM will take, regardless of other factors
+
+#VARIABLEDT
+T			DoVarDt			! If set to T RAM will adjust its time step based on the current fluxes using the Courant condition
+
+#COMPONENT_TIMESTEPS
+300.0			SCBTimeStep		! Amount of time (in seconds) between calls to SCB. If set to 1.0 it will call SCB on every RAM time step
+300.0			BCTimeStep		! Amount of time (in seconds) between reading boundary flux files (or from SWMF). If set to 1.0 will update on every RAM time step
+300.0			EFTimeStep		! Amount of time (in seconds) between updating electric fields. If set to 1.0 it will update every RAM time step
+
+! If this is present then the SCBTimeStep will be read as number of RAM iterations to do, not seconds
+#TIE_SCB_TO_RAM
+			
+***********************************************
+
+*************** COMPONENT BLOCK ***************
+#OUTERBOUNDARY
+LANL			NameBoundPlasma		! Determines the boundary flux source
+ReplBfield 			NameBoundMag		! Determines the magnetic field source (DIPL, DIPS, T89D, T89I, T89L)
+MAXW			NameDistribution	! Determines the distribution of the flux (MAXW)
+
+#EFIELD
+VOLS			NameEfield		! Determines the method for calculation the electric field (VOLS, WESC, W5SC, or RSCE)
+F			UseEfInd		! Whether or not to use an inductive electric field
+***********************************************
+
+***************** RAM BLOCK *******************
+#RAMGRID
+20                      nR                      ! Number of radial grid points used in RAM
+49                      nT                      ! Number of toroidal/local time grid points (25 default; 49 preferred)
+35                      nE                      ! Number of energy bins used
+72                      nPa                     ! Number of pitch angle bins used
+
+#PLASMASPHERE
+F			    UsePlasmasphere        ! Whether to include the plasmasphere
+Carpenter       PlasmasphereModel      ! Transport model name: Carpenter, Transport
+Analytic        RefillingTau           ! Refilling model name: Fixed, Analytic, Rasmussen
+
+#COULOMB
+F               UseCoulomb             ! If True, use Coulomb collisions
+***********************************************
+
+***************** SCB BLOCK *******************
+#SCB_CONVERGENCE
+0.9			ConvergenceDistance	! Minimum accuracy that needs to be reached regardless of other factors (between 0 and 1)
+
+#PRESS_MODE
+SKD         PressureMode    ! Options are SKD, ROE, EXT, FLT, and BAT. BAT is for use with the SWMF.
+
+#SCBSETTINGS
+1			MinSCBIterations	! Minimum number of outer SOR Iterations performed by SCB
+2                       SCBMethod		! Which inner SCB method to use (1 = Direct Matrix Inversion, 2 = SOR Iterations, 3 = No SCB)
+1			OuterMethod		! Which outer SCB method to use (1 = Picard Iteration, 2 = Newton Method)
+1E-10                   InnerConvergenceAlpha   ! Convergence criteria for the Alpha residual
+1E-8                    InnerConvergencePsi	! Convergence Criteria for the Psi residual
+
+#SCBGRID
+71                      nTheta                  ! Number of theta (polar) grid points used in SCB
+45                      nPsi                    ! Number of psi (radial) surfaces used in SCB
+73                      nZeta                   ! Number of zeta (azimuthal) surfaces used in SCB 
+
+#SCBFLAGS
+F			Isotropic		! Whether to use isotropic pressure mappings in SCB (does not effect RAM)
+F			ReduceAnisotropy	! Whether to change the anisotropy to a marginally mirror-stable
+T			BetaExtrapolation	! Whether to extrapolate Beta Euler potential values to the outside boundary or use the previous point (Currently unused)
+F			AzimuthalOffset		! Whether to set equidistance at most problematic time (if T) or keep it at midnight (if F)
+F			EmptyLossCone		! Whether to use a filled loss cone (if F) or a more realistic empty loss cone using M. Liemohn's 2004
+T			AdaptiveMesh		! Whether to use Mesh refinement in magnetic flux, so that one has equidistant magnetic flux surfaces
+
+#SCBDETAILS
+F			SORDetail		! Whether to compute extra Sucessive Over Relaxation information
+T			EnergyDetail		! Whether to compute DPS Dst and other energy information
+F			ForceBalanceDetail	! Whether to compute global force balance before and after SCB runs, this will cause additional output
+F			PressureDetail          ! Whether to compute the full 3D pressure profile before an SCB run, this will cause additional output
+
+***********************************************
+
+***************** INPUT BLOCK *****************
+#OMNIFILE
+omni.txt		NameOmniFile		! Name of the omni input file (needed if using the WESC, W5SC, or RSCE electric fields)
+
+#OMNIFILESOURCE
+F			UseSWMFFormat		! Whether the omni file is in the SMWF format or the older RAM format
+
+#INDICES_FILE
+RamIndices.txt		NameIndicesFile		! Name of the KP and F10.7 indices file needed for RAM (included in default installation)
+
+#BOUNDARY_FILE_PATH
+IM/input_ram/		BoundaryPath		! Location where the flux boundary files can be found (needed by RAM)
+
+#QINDENTON_FILE_PATH
+IM/input_scb/		QinDentonPath		! Location where the QinDenton files can be found (Used for the T##X magnetic field models)
+
+#INITIALIZATION_FILE_PATH
+IM/input_ram/		InitializationPath	! Location where the RAM Initialization.nc file can be found (included in default installation)
+
+***********************************************
+
+***************** OUTPUT BLOCK ****************
+#SAVERESTART
+3600.0			DtSaveRestart		! How often a restart file should be written (in seconds), -1.0 will disable restart files
+T			DoSaveFinalRestart	! Whether a restart file should be written on RAM finishing
+
+#TIMEDRESTART
+F			TimedRestartFiles	! Whether to time stamp the restart files. If F only one restart file will be made and it will be overwritten
+
+#LOGFILE
+60.0			DtLogFileWrite		! How often the log file should be appended (in seconds).
+
+#OUTPUT_FREQUENCY
+3600.0			DtPressureFileWrite	! How often RAM equatorial pressures should be written (in seconds)
+3600.0			DthIFileWrite		! How often SCB hI files should be written (in seconds)
+3600.0			DtEFieldFileWrite	! How often electric field files should be written
+3600.0			DtMAGxyzFileWrite	! How often x, y, and z from SCB should be written
+
+#SAVEFLUX
+3600.0			DoSaveFlux		! Output frequency [s] for writing RAM flux files (-1 turns output off)
+
+#DUMP3DFLUX
+F			DoDump3DFlux		! Whether SCB 3D flux files should be written or not (currently outputs 3D flux every hour)
+
+SATELLITE
+60.0			DtOutput		! How often satellite trajectory output files should be written (in seconds)
+2			nSatellite		! How many satellite trajectory input files are being used
+sat1.dat		NameTrajectoryFile	! The names of all of the satellite trajectory input files, should be a single line for each of the nSatellite
+sat2.dat		NameTrajectoryFile
+F			DoUseVAPini		! Whether to initialize based on VAP data (currently disabled)
+
+***********************************************

--- a/launch_run.py
+++ b/launch_run.py
@@ -3,8 +3,8 @@
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from contextlib import contextmanager
 import datetime as dt
-import io
 import os
+import sys
 import re
 import shutil
 import subprocess
@@ -80,6 +80,7 @@ def parse_config(config_file):
     print('LAUNCH_RUN: Requested {} to {}'.format(st_date, end_date))
     lastramind = get_ramindices_end()
     print('LAUNCH_RUN: RamIndices ends at {}'.format(lastramind))
+    sys.stdout.flush()
     if end_date >= lastramind:
         # if run ends after the last date in the Ramindices file,
         # update it
@@ -105,11 +106,12 @@ def setup_rundir(args):
     compl = subprocess.run(['make', 'rundir', 'RUNDIR=run_ram_ror'],
                            check=True, capture_output=True)
     # then make flux boundary files
-    cmdline = ' '.join(['python', '../flux-model/makeGEOboundary.py',
+    cmdline = ' '.join(['python', '/SHIELDS/flux-model/makeGEOboundary.py',
                         f'-s {stYYMMDD}', f'-e {enYYMMDD} -m 0',
-                        '-r input'])
+                        '-r input -o run_ram_ror/input_ram'])
     compl = subprocess.run(cmdline, shell=True,
                            check=True, stdout=subprocess.PIPE)
+    sys.stdout.flush()
     # add supplied PARAM file
     shutil.copyfile(args.configfile[0], 'run_ram_ror/PARAM.in')
     # and move rundir to final location


### PR DESCRIPTION
This PR deals with updates for transitioning RAM-SCB for runs-on-request at NASA's CCMC. This is being done through a containerized application with a single entrypoint (`launch_run.py`) that handles run directory creation, input file collation/creation, launching simulation, etc.

- The updates to the `.dockerignore` are intended to reduce RoR image size by excluding git history, etc. when building from the parent directory of RAM-SCB (which, for RoR, requires the flux model to have the same parent directory)
- Notes are included in `Dockerfile.RoR` to aid in building and running a RAM-SCB container
- `Dockerfile.RoR` now installs pip from the package manager, then installs numpy and spacepy (required by the boundary file generation script; spacepy will also be required for plotting and this PR will be taken out of draft when minimal auto-plotting is added to the RoR application)
- `PARAM.in.RoR` provides a template `PARAM.in` file with unique strings to be replaced by the RoR web interface such that user configuration can be passed through to the launch script
- `launch_run.py` has been updated to parse the start and stop times from the provided param file and to log (to stdout) and generate flux boundary files for the run