### PR TITLE
Plotting updates for CCMC runs-on-request

### DIFF
--- a/Param/PARAM.in.RoR
+++ b/Param/PARAM.in.RoR
@@ -42,9 +42,6 @@ T			DoVarDt			! If set to T RAM will adjust its time step based on the current f
 300.0			BCTimeStep		! Amount of time (in seconds) between reading boundary flux files (or from SWMF). If set to 1.0 will update on every RAM time step
 300.0			EFTimeStep		! Amount of time (in seconds) between updating electric fields. If set to 1.0 it will update every RAM time step
 
-! If this is present then the SCBTimeStep will be read as number of RAM iterations to do, not seconds
-#TIE_SCB_TO_RAM
-			
 ***********************************************
 
 *************** COMPONENT BLOCK ***************
@@ -148,7 +145,7 @@ F			TimedRestartFiles	! Whether to time stamp the restart files. If F only one r
 3600.0			DtMAGxyzFileWrite	! How often x, y, and z from SCB should be written
 
 #SAVEFLUX
-3600.0			DoSaveFlux		! Output frequency [s] for writing RAM flux files (-1 turns output off)
+300.0			DoSaveFlux		! Output frequency [s] for writing RAM flux files (-1 turns output off)
 
 #DUMP3DFLUX
 F			DoDump3DFlux		! Whether SCB 3D flux files should be written or not (currently outputs 3D flux every hour)

--- a/Scripts/summaryPlots.py
+++ b/Scripts/summaryPlots.py
@@ -101,7 +101,7 @@ def plotDst(log, options):
     if options.endTime:
         opt_ten = spt.Ticktock(options.endTime).UTC[0]
         # end needs to be in valid range
-        if (opt_ten > tstart) and (opt_ten < tend):
+        if (opt_ten >= tstart) and (opt_ten <= tend):
             tend = opt_ten
         else:
             warnings.warn(f'Supplied end time ({options.endTime}) ' +
@@ -151,8 +151,11 @@ def plot_pressure(options):
             # plotlist = [key for key in pressf if (key.startswith('tot') or key.startswith('ani'))]
             for pl in plotlist:
                 # TODO: maybe make combined plots, look at axis limits, etc.
-                fig, ax, cm, _ = pressf.add_pcol_press(var=pl, add_cbar=True)
+                title = '{}'.format(pressf[pl].attrs['label'])
+                tstamp = '{}'.format(ftime.isoformat()[:19])
+                fig, ax, cm, _ = pressf.add_pcol_press(var=pl, add_cbar=True, title=title)
                 outfn = os.path.join(options.outdir, fmain + f'_{pl}.png')
+                plt.figtext(0.05, 0.95, tstamp, fontsize=11)
                 plt.savefig(outfn, dpi=200)
                 plt.close()
 

--- a/launch_run.py
+++ b/launch_run.py
@@ -151,12 +151,13 @@ def run_model(args):
 def make_plots(args, st_date, en_date):
     '''
     '''
-    stdt = st_date.isoformat()[:10]
-    endt = end_date.isoformat()[:10]
+    stdt = st_date.isoformat()[:19]
+    endt = end_date.isoformat()[:19]
     with cd('Scripts'):
         cmdline = ' '.join(['python', 'summaryPlots.py', f'-s {stdt}',
                            f'-e {endt}', f'-o {args.destdir}',
                            f'{args.destdir}'])
+        print(cmdline)
         subprocess.run(cmdline, shell=True, check=True,
                        stdout=subprocess.PIPE)
 


### PR DESCRIPTION
Fixes some issues in runs-on-request automation:
- The time range passed from the launch script to the plot script was being truncated to day boundaries leading to the last day of a run not being plotted. This is now fixed and the times are passed to minute precision.
- A timestamp annotation was added to the pressure plots (these are displayed on the RoR output webpage and file metadata is not available, so a timestamp is required)